### PR TITLE
fix: 32-bit platform build (GOARCH=386)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,28 @@ jobs:
         flags: unittests
         name: codecov-unit
 
+  # 32-bit build verification (GOARCH=386)
+  # GoAWK tests on 386, we must support it
+  build-386:
+    name: Build - Linux 386
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.25'
+        cache: true
+
+    - name: Build for 386
+      run: GOARCH=386 go build ./...
+
+    - name: Run tests for 386
+      run: GOARCH=386 go test -short ./...
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.8.13] - 2025-12-08
+
+### Fixed
+- **32-bit platform support**: Fixed build failure on GOARCH=386
+  - `internal/conv.IntToUint32()` used `n > math.MaxUint32` which overflows on 32-bit
+  - Changed to `uint(n) > math.MaxUint32` for portable comparison
+  - Discovered via GoAWK CI testing on Linux 386
+
+---
+
 ## [0.8.12] - 2025-12-08
 
 ### Added

--- a/internal/conv/conv.go
+++ b/internal/conv/conv.go
@@ -12,10 +12,12 @@ import "math"
 //
 //go:inline
 func IntToUint32(n int) uint32 {
-	if n < 0 || n > math.MaxUint32 {
+	// Use uint for comparison to avoid overflow on 32-bit platforms
+	// where int cannot represent math.MaxUint32
+	if n < 0 || uint(n) > math.MaxUint32 {
 		panic("integer overflow: int value out of uint32 range")
 	}
-	return uint32(n)
+	return uint32(n) //nolint:gosec // bounds checked above
 }
 
 // IntToUint16 safely converts an int to uint16.


### PR DESCRIPTION
## Summary

- Fixed build failure on 32-bit platforms (GOARCH=386)
- `IntToUint32()` used `n > math.MaxUint32` which overflows on 32-bit where `int` is 32-bit signed
- Changed to `uint(n) > math.MaxUint32` for portable comparison

## Context

Discovered via GoAWK CI: https://github.com/benhoyt/goawk/actions/runs/20039826964/job/57470760372

On 32-bit:
- `int` max = 2^31-1 = 2,147,483,647
- `math.MaxUint32` = 2^32-1 = 4,294,967,295
- Comparison `int > MaxUint32` causes compile-time overflow

## Test plan

- [x] `GOARCH=386 go build ./...` passes
- [x] All tests pass
- [x] Pre-release check passes