### PR TITLE
perf: zero-allocation IsMatch and FindIndices (Fixes #31, #32)

### DIFF
--- a/regex.go
+++ b/regex.go
@@ -233,11 +233,12 @@ func (r *Regex) MatchString(s string) bool {
 //	match := re.Find([]byte("age: 42"))
 //	println(string(match)) // "42"
 func (r *Regex) Find(b []byte) []byte {
-	match := r.engine.Find(b)
-	if match == nil {
+	// Use zero-allocation FindIndices internally
+	start, end, found := r.engine.FindIndices(b)
+	if !found {
 		return nil
 	}
-	return match.Bytes()
+	return b[start:end]
 }
 
 // FindString returns a string holding the text of the leftmost match in s.
@@ -266,11 +267,12 @@ func (r *Regex) FindString(s string) string {
 //	loc := re.FindIndex([]byte("age: 42"))
 //	println(loc[0], loc[1]) // 5, 7
 func (r *Regex) FindIndex(b []byte) []int {
-	match := r.engine.Find(b)
-	if match == nil {
+	// Use zero-allocation FindIndices internally
+	start, end, found := r.engine.FindIndices(b)
+	if !found {
 		return nil
 	}
-	return []int{match.Start(), match.End()}
+	return []int{start, end}
 }
 
 // FindStringIndex returns a two-element slice of integers defining the location


### PR DESCRIPTION
## Summary

- **PikeVM.IsMatch()**: Fast boolean-only matching that returns immediately on first match without computing positions - zero allocations
- **Engine.FindIndices()**: Zero-allocation alternative to Find() returning `(start, end, found)` tuple
- **Public API updated**: `Find()` and `FindIndex()` now use `FindIndices()` internally

## Performance Results

| Method | Before | After |
|--------|--------|-------|
| `IsMatch()` | 48 B/op, 1 allocs | **0 B/op, 0 allocs** ✅ |
| `Find()` | 48 B/op, 1 allocs | 48 B/op, 1 allocs (API slice) |
| `FindIndices()` (new) | N/A | **0 B/op, 0 allocs** ✅ |

### IsMatch vs stdlib (ReverseSuffix strategy)

| Input Size | coregex | stdlib | Speedup |
|------------|---------|--------|---------|
| 1KB | 216.5 ns | 11074 ns | **52x** |
| 32KB | 419.9 ns | 458222 ns | **1090x** |
| 1MB | 8145 ns | 15163771 ns | **1863x** |

## Changes

- `nfa/pikevm.go`: Added `IsMatch()`, `isMatchAnchored()`, `isMatchUnanchored()` and helper methods
- `meta/meta.go`: Added `FindIndices()`, `FindIndicesAt()` and all strategy-specific implementations
- `regex.go`: Updated `Find()` and `FindIndex()` to use `FindIndices()` internally

## Test Plan

- [x] `go test ./...` - all tests pass
- [x] `go test -race ./...` - no race conditions
- [x] `golangci-lint run` - no linter issues
- [x] Benchmarks show expected improvements

Fixes #31, Fixes #32