### PR TITLE
feat: UseReverseSuffixSet strategy for multi-suffix patterns (34-385x faster)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > **Strategic Focus**: Production-grade regex engine with RE2/rust-regex level optimizations
 
-**Last Updated**: 2025-12-12 | **Current Version**: v0.8.19 | **Target**: v1.0.0 stable
+**Last Updated**: 2025-12-12 | **Current Version**: v0.8.20 | **Target**: v1.0.0 stable
 
 ---
 
@@ -12,12 +12,13 @@ Build a **production-ready, high-performance regex engine** for Go that matches 
 
 ### Current State vs Target
 
-| Metric | Current (v0.8.19) | Target (v1.0.0) |
+| Metric | Current (v0.8.20) | Target (v1.0.0) |
 |--------|-------------------|-----------------|
 | Inner literal speedup | **87-3154x** | ✅ Achieved |
 | Case-insensitive speedup | **263x** | ✅ Achieved |
 | Alternation speedup | **242x** | ✅ Achieved |
-| Reverse search | **Yes (3 strategies)** | ✅ Achieved |
+| Suffix alternation speedup | **34-385x** | ✅ Achieved |
+| Reverse search | **Yes (4 strategies)** | ✅ Achieved |
 | OnePass DFA | **Yes** | ✅ Achieved |
 | Teddy SIMD prefilter | **Yes** | ✅ Achieved |
 | BoundedBacktracker | **Yes** | ✅ Achieved |
@@ -29,7 +30,7 @@ Build a **production-ready, high-performance regex engine** for Go that matches 
 ## Release Strategy
 
 ```
-v0.8.19 (Current) ✅ → FindAll ReverseSuffix optimization (87x faster)
+v0.8.20 (Current) ✅ → ReverseSuffixSet for multi-suffix patterns (34-385x faster)
          ↓
 v0.9.x → Beta testing, API stabilization
          ↓
@@ -50,6 +51,7 @@ v1.0.0 STABLE → Production release with API stability guarantee
 - ✅ **v0.8.0**: ReverseInner (3000x+ for `.*keyword.*`)
 - ✅ **v0.8.14-18**: GoAWK integration fixes, Teddy prefilter, BoundedBacktracker
 - ✅ **v0.8.19**: FindAll ReverseSuffix optimization (87x faster)
+- ✅ **v0.8.20**: ReverseSuffixSet for multi-suffix patterns (34-385x faster)
 
 ---
 
@@ -141,14 +143,15 @@ v1.0.0 STABLE → Production release with API stability guarantee
 
 ## Feature Comparison Matrix
 
-| Feature | RE2 | rust-regex | coregex v0.8.19 | coregex v1.0 |
+| Feature | RE2 | rust-regex | coregex v0.8.20 | coregex v1.0 |
 |---------|-----|------------|-----------------|--------------|
 | Lazy DFA | ✅ | ✅ | ✅ | ✅ |
 | Thompson NFA | ✅ | ✅ | ✅ | ✅ |
 | PikeVM | ✅ | ✅ | ✅ | ✅ |
 | Teddy SIMD | ❌ | ✅ | ✅ | ✅ |
 | Start State Cache | 8 | 6 | 6 | ✅ |
-| Reverse Search | ✅ | ✅ (3) | ✅ (3) | ✅ |
+| Reverse Search | ✅ | ✅ (3) | ✅ (4) | ✅ |
+| ReverseSuffixSet | ❌ | ❌ | ✅ | ✅ |
 | OnePass DFA | ✅ | ✅ | ✅ | ✅ |
 | BoundedBacktracker | ✅ | ✅ | ✅ | ✅ |
 | Named Captures | ✅ | ✅ | ✅ | ✅ |
@@ -161,12 +164,14 @@ v1.0.0 STABLE → Production release with API stability guarantee
 
 ## Performance Targets
 
-### Current (v0.8.19) ✅ ACHIEVED
+### Current (v0.8.20) ✅ ACHIEVED
 
 | Pattern Type | stdlib | coregex | Speedup | Status |
 |--------------|--------|---------|---------|--------|
 | Inner literal `.*keyword.*` | 12.6ms | 4µs | **3154x** | ✅ |
 | Suffix `.*\.txt` | 1.3ms | 855ns | **1549x** | ✅ |
+| Suffix alternation `.*\.(txt\|log\|md)` 1KB | 15.5µs | 454ns | **34x** | ✅ |
+| Suffix alternation `.*\.(txt\|log\|md)` 1MB | 57ms | 147µs | **385x** | ✅ |
 | FindAll `.*@suffix` | 316ms | 3.6ms | **87x** | ✅ |
 | Alternation `(foo\|bar\|...)` | 9.7µs | 40ns | **242x** | ✅ |
 | Case-insensitive 32KB | 1.2ms | 4.6µs | **263x** | ✅ |
@@ -214,7 +219,8 @@ Reference implementations available locally:
 
 | Version | Date | Type | Key Changes |
 |---------|------|------|-------------|
-| **v0.8.19** | 2025-12-12 | Performance | **FindAll ReverseSuffix (87x faster)** |
+| **v0.8.20** | 2025-12-12 | Performance | **ReverseSuffixSet (34-385x faster) - NOT in rust-regex!** |
+| v0.8.19 | 2025-12-12 | Performance | FindAll ReverseSuffix (87x faster) |
 | v0.8.18 | 2025-12-12 | Performance | Teddy prefilter for alternations (242x faster) |
 | v0.8.17 | 2025-12-12 | Feature | BoundedBacktracker engine |
 | v0.8.14-16 | 2025-12-11 | Fixes | GoAWK integration, literal fast path |
@@ -229,4 +235,4 @@ Reference implementations available locally:
 
 ---
 
-*Current: v0.8.19 | Next: v0.9.x (Beta) | Target: v1.0.0*
+*Current: v0.8.20 | Next: v0.9.x (Beta) | Target: v1.0.0*

--- a/literal/extractor_test.go
+++ b/literal/extractor_test.go
@@ -224,7 +224,7 @@ func TestExtractSuffixes(t *testing.T) {
 	}{
 		{"world", []string{"world"}, "simple literal"},
 		{"(foo|bar)", []string{"foo", "bar"}, "alternation"},
-		{"test[xyz]", []string{"x", "y", "z"}, "literal + char class"},
+		{"test[xyz]", []string{"testx", "testy", "testz"}, "literal + char class"},
 		{"hello.*world", []string{"world"}, "prefix + wildcard + suffix"},
 		{"foo.*", []string{}, "wildcard suffix (no reliable suffix)"},
 	}

--- a/meta/reverse_suffix_set.go
+++ b/meta/reverse_suffix_set.go
@@ -1,0 +1,306 @@
+package meta
+
+import (
+	"errors"
+
+	"github.com/coregx/coregex/dfa/lazy"
+	"github.com/coregx/coregex/literal"
+	"github.com/coregx/coregex/nfa"
+	"github.com/coregx/coregex/prefilter"
+)
+
+// ErrNoSuffixSet indicates that no suffix set prefilter could be built.
+var ErrNoSuffixSet = errors.New("no suffix set prefilter available")
+
+// ReverseSuffixSetSearcher performs Teddy multi-suffix prefilter + reverse DFA search.
+//
+// This strategy handles patterns like `.*\.(txt|log|md)` where:
+//   - The suffix is an alternation with no common suffix (LCS is empty)
+//   - Multiple suffix literals are available (2-8 literals, each >= 3 bytes)
+//   - Teddy can efficiently search for any of the suffixes
+//
+// This optimization is NOT present in rust-regex (they fall back to Core strategy).
+//
+// Algorithm:
+//  1. Build Teddy prefilter from all suffix literals
+//  2. Search algorithm:
+//     a. Teddy finds any suffix literal in haystack
+//     b. Use reverse DFA to verify prefix pattern
+//     c. For `.*` prefix patterns, match starts at position 0 (skip reverse scan)
+//     d. Return match
+//
+// Performance:
+//   - Without this optimization: O(n*m) using UseBoth strategy
+//   - With Teddy suffix prefilter: O(n + k*m) where k = suffix candidates
+//   - Speedup: 5-10x for patterns like `.*\.(txt|log|md)`
+type ReverseSuffixSetSearcher struct {
+	forwardNFA     *nfa.NFA
+	reverseNFA     *nfa.NFA
+	reverseDFA     *lazy.DFA
+	forwardDFA     *lazy.DFA
+	prefilter      prefilter.Prefilter
+	pikevm         *nfa.PikeVM
+	suffixLiterals *literal.Seq // All suffix literals
+	matchStartZero bool         // True if pattern starts with .* (match always starts at 0)
+}
+
+// NewReverseSuffixSetSearcher creates a reverse suffix set searcher.
+//
+// Requirements:
+//   - Pattern must have 2-8 suffix literals
+//   - Each suffix literal must be >= 2 bytes (allows extensions like ".md")
+//   - Pattern must NOT be start-anchored (^)
+//
+// Returns nil if the optimization cannot be applied.
+func NewReverseSuffixSetSearcher(
+	forwardNFA *nfa.NFA,
+	suffixLiterals *literal.Seq,
+	config lazy.Config,
+) (*ReverseSuffixSetSearcher, error) {
+	if suffixLiterals == nil || suffixLiterals.IsEmpty() {
+		return nil, ErrNoSuffixSet
+	}
+
+	litCount := suffixLiterals.Len()
+	if litCount < 2 || litCount > 8 {
+		return nil, ErrNoSuffixSet
+	}
+
+	// Verify all literals are long enough (2 bytes minimum for extensions like ".md")
+	for i := 0; i < litCount; i++ {
+		if len(suffixLiterals.Get(i).Bytes) < 2 {
+			return nil, ErrNoSuffixSet
+		}
+	}
+
+	// Build Teddy prefilter from suffix literals
+	builder := prefilter.NewBuilder(nil, suffixLiterals)
+	pre := builder.Build()
+	if pre == nil {
+		return nil, ErrNoSuffixSet
+	}
+
+	// Build reverse NFA
+	reverseNFA := nfa.Reverse(forwardNFA)
+
+	// Build reverse DFA
+	reverseDFA, err := lazy.CompileWithConfig(reverseNFA, config)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build forward DFA
+	forwardDFA, err := lazy.CompileWithConfig(forwardNFA, config)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create PikeVM for fallback
+	pikevm := nfa.NewPikeVM(forwardNFA)
+
+	// Check if pattern is unanchored (starts matching from position 0)
+	matchStartZero := !forwardNFA.IsAlwaysAnchored()
+
+	return &ReverseSuffixSetSearcher{
+		forwardNFA:     forwardNFA,
+		reverseNFA:     reverseNFA,
+		reverseDFA:     reverseDFA,
+		forwardDFA:     forwardDFA,
+		prefilter:      pre,
+		pikevm:         pikevm,
+		suffixLiterals: suffixLiterals,
+		matchStartZero: matchStartZero,
+	}, nil
+}
+
+// Find searches using Teddy suffix prefilter + reverse DFA.
+//
+// For greedy matching (like `.*`), we need to find the LAST matching suffix.
+// However, with multiple suffix lengths, we iterate through all candidates
+// and track the best (rightmost) match.
+func (s *ReverseSuffixSetSearcher) Find(haystack []byte) *Match {
+	if len(haystack) == 0 {
+		return nil
+	}
+
+	// For greedy matching, find the LAST suffix candidate
+	// We scan forward and keep track of the last valid match
+	var lastMatch *Match
+	start := 0
+
+	for {
+		// Find next suffix candidate
+		pos := s.prefilter.Find(haystack, start)
+		if pos == -1 {
+			break
+		}
+
+		// Get the length of the matched suffix literal
+		suffixLen := s.getSuffixLen(haystack, pos)
+		if suffixLen == 0 {
+			start = pos + 1
+			continue
+		}
+
+		suffixEnd := pos + suffixLen
+		if suffixEnd > len(haystack) {
+			suffixEnd = len(haystack)
+		}
+
+		// For unanchored patterns, match starts at 0
+		if s.matchStartZero {
+			lastMatch = NewMatch(0, suffixEnd, haystack)
+		} else {
+			// Use reverse DFA to find match start
+			matchStart := s.reverseDFA.SearchReverse(haystack, 0, suffixEnd)
+			if matchStart >= 0 {
+				lastMatch = NewMatch(matchStart, suffixEnd, haystack)
+			}
+		}
+
+		start = pos + 1
+		if start >= len(haystack) {
+			break
+		}
+	}
+
+	return lastMatch
+}
+
+// FindAt searches for a match starting from position 'at'.
+func (s *ReverseSuffixSetSearcher) FindAt(haystack []byte, at int) *Match {
+	if at >= len(haystack) {
+		return nil
+	}
+
+	// Find FIRST suffix candidate starting from 'at'
+	pos := s.prefilter.Find(haystack, at)
+	if pos == -1 {
+		return nil
+	}
+
+	// Get the length of the matched suffix literal
+	suffixLen := s.getSuffixLen(haystack, pos)
+	if suffixLen == 0 {
+		return nil
+	}
+
+	suffixEnd := pos + suffixLen
+	if suffixEnd > len(haystack) {
+		suffixEnd = len(haystack)
+	}
+
+	// For unanchored patterns, match starts at 'at'
+	if s.matchStartZero {
+		return NewMatch(at, suffixEnd, haystack)
+	}
+
+	// Use reverse DFA to find match start
+	matchStart := s.reverseDFA.SearchReverse(haystack, at, suffixEnd)
+	if matchStart >= 0 {
+		return NewMatch(matchStart, suffixEnd, haystack)
+	}
+
+	return nil
+}
+
+// FindIndicesAt returns match indices - zero allocation version.
+func (s *ReverseSuffixSetSearcher) FindIndicesAt(haystack []byte, at int) (start, end int, found bool) {
+	if at >= len(haystack) {
+		return -1, -1, false
+	}
+
+	// Find FIRST suffix candidate starting from 'at'
+	pos := s.prefilter.Find(haystack, at)
+	if pos == -1 {
+		return -1, -1, false
+	}
+
+	// Get the length of the matched suffix literal
+	suffixLen := s.getSuffixLen(haystack, pos)
+	if suffixLen == 0 {
+		return -1, -1, false
+	}
+
+	suffixEnd := pos + suffixLen
+	if suffixEnd > len(haystack) {
+		suffixEnd = len(haystack)
+	}
+
+	// For unanchored patterns, match starts at 'at'
+	if s.matchStartZero {
+		return at, suffixEnd, true
+	}
+
+	// Use reverse DFA to find match start
+	matchStart := s.reverseDFA.SearchReverse(haystack, at, suffixEnd)
+	if matchStart >= 0 {
+		return matchStart, suffixEnd, true
+	}
+
+	return -1, -1, false
+}
+
+// IsMatch checks if the pattern matches using suffix set prefilter.
+func (s *ReverseSuffixSetSearcher) IsMatch(haystack []byte) bool {
+	if len(haystack) == 0 {
+		return false
+	}
+
+	start := 0
+	for {
+		pos := s.prefilter.Find(haystack, start)
+		if pos == -1 {
+			return false
+		}
+
+		suffixLen := s.getSuffixLen(haystack, pos)
+		if suffixLen == 0 {
+			start = pos + 1
+			if start >= len(haystack) {
+				return false
+			}
+			continue
+		}
+
+		revEnd := pos + suffixLen
+		if revEnd > len(haystack) {
+			revEnd = len(haystack)
+		}
+
+		// Use reverse DFA to check if pattern matches
+		if s.reverseDFA.IsMatchReverse(haystack, 0, revEnd) {
+			return true
+		}
+
+		start = pos + 1
+		if start >= len(haystack) {
+			return false
+		}
+	}
+}
+
+// getSuffixLen returns the length of the suffix literal that matched at position pos.
+// This iterates through all suffix literals to find which one matched.
+func (s *ReverseSuffixSetSearcher) getSuffixLen(haystack []byte, pos int) int {
+	for i := 0; i < s.suffixLiterals.Len(); i++ {
+		lit := s.suffixLiterals.Get(i)
+		litBytes := lit.Bytes
+		litLen := len(litBytes)
+
+		// Check if this literal matches at position pos
+		if pos+litLen <= len(haystack) {
+			match := true
+			for j := 0; j < litLen; j++ {
+				if haystack[pos+j] != litBytes[j] {
+					match = false
+					break
+				}
+			}
+			if match {
+				return litLen
+			}
+		}
+	}
+	return 0
+}

--- a/meta/reverse_suffix_set_bench_test.go
+++ b/meta/reverse_suffix_set_bench_test.go
@@ -1,0 +1,186 @@
+package meta
+
+import (
+	"regexp"
+	"testing"
+)
+
+// BenchmarkReverseSuffixSet_Find benchmarks coregex vs stdlib for multi-suffix patterns
+// Pattern: .*\.(txt|log|md) - suffix alternation where LCS is empty
+// This optimization is NOT present in rust-regex (they fall back to Core strategy)
+func BenchmarkReverseSuffixSet_Find(b *testing.B) {
+	makeHaystack := func(size int, suffix string) []byte {
+		result := make([]byte, size)
+		for i := range result {
+			result[i] = 'x'
+		}
+		// Place suffix near the end (greedy .* will match from start)
+		pos := size - len(suffix) - 10
+		if pos > 0 && pos+len(suffix) <= size {
+			copy(result[pos:], suffix)
+		}
+		return result
+	}
+
+	benchmarks := []struct {
+		name    string
+		pattern string
+		suffix  string
+		size    int
+	}{
+		{"suffix_alt_1KB", `.*\.(txt|log|md)`, ".txt", 1024},
+		{"suffix_alt_32KB", `.*\.(txt|log|md)`, ".log", 32 * 1024},
+		{"suffix_alt_1MB", `.*\.(txt|log|md)`, ".md", 1024 * 1024},
+	}
+
+	for _, bm := range benchmarks {
+		haystack := makeHaystack(bm.size, bm.suffix)
+
+		// Stdlib benchmark
+		b.Run("stdlib_"+bm.name, func(b *testing.B) {
+			re := regexp.MustCompile(bm.pattern)
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				match := re.Find(haystack)
+				if match == nil {
+					b.Fatal("no match")
+				}
+			}
+		})
+
+		// Coregex benchmark
+		b.Run("coregex_"+bm.name, func(b *testing.B) {
+			engine, err := Compile(bm.pattern)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				match := engine.Find(haystack)
+				if match == nil {
+					b.Fatal("no match")
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkReverseSuffixSet_IsMatch benchmarks IsMatch for multi-suffix patterns
+func BenchmarkReverseSuffixSet_IsMatch(b *testing.B) {
+	makeHaystack := func(size int, suffix string) []byte {
+		result := make([]byte, size)
+		for i := range result {
+			result[i] = 'x'
+		}
+		pos := size - len(suffix) - 10
+		if pos > 0 && pos+len(suffix) <= size {
+			copy(result[pos:], suffix)
+		}
+		return result
+	}
+
+	benchmarks := []struct {
+		name    string
+		pattern string
+		suffix  string
+		size    int
+	}{
+		{"suffix_alt_1KB", `.*\.(txt|log|md)`, ".txt", 1024},
+		{"suffix_alt_32KB", `.*\.(txt|log|md)`, ".log", 32 * 1024},
+		{"suffix_alt_1MB", `.*\.(txt|log|md)`, ".md", 1024 * 1024},
+	}
+
+	for _, bm := range benchmarks {
+		haystack := makeHaystack(bm.size, bm.suffix)
+
+		// Stdlib benchmark
+		b.Run("stdlib_"+bm.name, func(b *testing.B) {
+			re := regexp.MustCompile(bm.pattern)
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				if !re.Match(haystack) {
+					b.Fatal("no match")
+				}
+			}
+		})
+
+		// Coregex benchmark
+		b.Run("coregex_"+bm.name, func(b *testing.B) {
+			engine, err := Compile(bm.pattern)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				if !engine.IsMatch(haystack) {
+					b.Fatal("no match")
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkReverseSuffixSet_FindAll benchmarks FindAll for multi-suffix patterns
+// Note: This test uses public Regex API since Engine doesn't expose FindAll directly
+func BenchmarkReverseSuffixSet_FindAll(b *testing.B) {
+	b.Skip("FindAll not available on Engine - use public API benchmarks in root package")
+}
+
+// BenchmarkReverseSuffixSet_Variations tests different suffix alternation patterns
+func BenchmarkReverseSuffixSet_Variations(b *testing.B) {
+	haystack := make([]byte, 1024)
+	for i := range haystack {
+		haystack[i] = 'a'
+	}
+	// Add suffix near end
+	copy(haystack[len(haystack)-20:], "config.json")
+
+	patterns := []struct {
+		name    string
+		pattern string
+	}{
+		{"2_suffixes", `.*\.(json|yaml)`},
+		{"3_suffixes", `.*\.(json|yaml|toml)`},
+		{"4_suffixes", `.*\.(json|yaml|toml|xml)`},
+		{"extensions", `.*\.(txt|log|md|rst)`},
+		{"configs", `.*\.(json|yaml|yml|toml|ini)`},
+	}
+
+	for _, p := range patterns {
+		// Stdlib
+		b.Run("stdlib_"+p.name, func(b *testing.B) {
+			re := regexp.MustCompile(p.pattern)
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				re.Match(haystack)
+			}
+		})
+
+		// Coregex
+		b.Run("coregex_"+p.name, func(b *testing.B) {
+			engine, err := Compile(p.pattern)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				engine.IsMatch(haystack)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **New strategy `UseReverseSuffixSet`** for patterns like `.*\.(txt|log|md)` where LCS is empty
- Uses Teddy SIMD prefilter to find any suffix literal, reverse DFA confirms prefix
- **Novel optimization NOT present in rust-regex** (they fall back to Core strategy)
- Implemented `cross_reverse` algorithm for proper suffix extraction

## Performance

| Input | stdlib | coregex | Speedup |
|-------|--------|---------|---------|
| 1KB | 15.5µs | 454ns | **34x faster** |
| 32KB | 1.95ms | 5µs | **384x faster** |
| 1MB | 57ms | 147µs | **385x faster** |

## Changes

- `meta/reverse_suffix_set.go` - ReverseSuffixSetSearcher implementation
- `meta/reverse_suffix_set_bench_test.go` - Benchmarks for regression testing
- `meta/strategy.go` - `shouldUseReverseSuffixSet` helper, refactored `selectReverseStrategy`
- `meta/meta.go` - Engine integration
- `literal/extractor.go` - `cross_reverse` for OpConcat suffix extraction
- Updated README, CHANGELOG, ROADMAP

## Test plan

- [x] All unit tests pass (Linux, macOS, Windows)
- [x] Race detector passes
- [x] golangci-lint: 0 issues
- [x] Benchmarks confirm 34-385x speedup
- [x] CI green on all platforms