### PR TITLE
perf: optimize small string matching with BoundedBacktracker (v0.8.22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.8.22] - 2025-12-13
+
+### Added
+- **Small string optimization** - BoundedBacktracker for NFA patterns (Issue #29)
+  - Patterns like `j[a-z]+p` now **1.4x faster than stdlib** (was 2-4x slower)
+  - `\w+`, `[a-z]+` patterns: **15-20x faster** via CharClassSearcher
+  - Zero allocations for all `*String` methods (MatchString, FindString, etc.)
+
+- **GoAWK benchmarks** - Added Ben Hoyt patterns for regression testing
+  - `j[a-z]+p`, `\w+`, `[a-z]+` in BenchmarkMatchString and BenchmarkIsMatch
+
+### Changed
+- **BoundedBacktracker** now auto-enabled for UseNFA strategy with small patterns (<50 states)
+  - Uses O(1) generation-based visited reset vs PikeVM's thread queues
+  - Only for patterns that cannot match empty (avoids greedy semantics bugs)
+
+### Technical
+- `regex.go`: Added `stringToBytes()` using `unsafe.Slice` (like Rust's `as_bytes()`)
+- `meta/meta.go`: Added `canMatchEmpty` detection, prefilter in NFA path
+- `meta/meta_test.go`: Added BenchmarkIsMatch with GoAWK patterns
+- `regex_test.go`: Added GoAWK patterns to BenchmarkMatchString, BenchmarkFindIndex
+
+### Performance (small strings ~44 bytes vs stdlib)
+
+| Operation | Pattern | Result |
+|-----------|---------|--------|
+| MatchString | `j[a-z]+p` | **1.4x faster** |
+| MatchString | `\w+` | **18x faster** |
+| MatchString | `[a-z]+` | **15x faster** |
+| FindStringIndex | `j[a-z]+p` | **1.45x faster** |
+| Split | `f[a-z]x` | **1.75x faster** |
+
+---
+
 ## [0.8.21] - 2025-12-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A **production-grade regex engine** for Go with dramatic performance improvement
 - ⚡ **OnePass DFA** for simple anchored patterns (10x faster captures, 0 allocs)
 - ⚡ **CharClassSearcher** for simple char_class patterns (`\w+`, `\d+`, `[a-z]+`) - **23x faster** than stdlib, **2x faster than Rust**!
 - ⚡ **BoundedBacktracker** for char_class with captures (`(\w)+`, `(a|b|c)+`) - 2.5x faster than stdlib
+- ⚡ **Small string optimization** (v0.8.22) - **1.4-20x faster** than stdlib on small inputs (~44 bytes)
 - 📌 **Prefilter coordination** (memchr/memmem/teddy)
 
 🎯 **API Design**
@@ -180,6 +181,7 @@ func benchmarkSearch(pattern string, text []byte) {
 | **`[\w]+`** | 6MB | 623 ms | **27 ms** | **23x faster** |
 | **`\d+`** | 1KB | 6.7 µs | **1.5 µs** | **4.5x faster** |
 | **`(a\|b\|c)+`** | 1KB | 7.3 µs | **3.0 µs** | **2.5x faster** |
+| **`j[a-z]+p` (small)** | 44B | 162 ns | **110 ns** | **1.4x faster** |
 | **Email pattern** | 1KB | 22 µs | **2 µs** | **11x faster** |
 | **Email pattern** | 32KB | 640 µs | **15 µs** | **42x faster** |
 
@@ -192,6 +194,7 @@ func benchmarkSearch(pattern string, text []byte) {
 - **Email patterns** now 11-42x faster via ReverseInner with `@` inner literal (v0.8.18)
 - **Simple char_class patterns** (`[\w]+`, `\d+`, `[a-z]+`) now **23x faster** via CharClassSearcher - **2x faster than Rust**! (v0.8.21)
 - **Char_class with captures** (`(\w)+`, `(a|b|c)+`) 2.5-4.5x faster via BoundedBacktracker (v0.8.17-18)
+- **Small strings** (~44 bytes) now **1.4-20x faster** via BoundedBacktracker + zero-alloc String methods (v0.8.22)
 - **Case-insensitive** patterns (`(?i)...`) are also excellent (100-263x) - stdlib backtracking is slow, our DFA is fast
 - **Simple patterns** see 1-5x improvement depending on literals
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > **Strategic Focus**: Production-grade regex engine with RE2/rust-regex level optimizations
 
-**Last Updated**: 2025-12-12 | **Current Version**: v0.8.20 | **Target**: v1.0.0 stable
+**Last Updated**: 2025-12-13 | **Current Version**: v0.8.22 | **Target**: v1.0.0 stable
 
 ---
 
@@ -12,16 +12,18 @@ Build a **production-ready, high-performance regex engine** for Go that matches 
 
 ### Current State vs Target
 
-| Metric | Current (v0.8.20) | Target (v1.0.0) |
+| Metric | Current (v0.8.22) | Target (v1.0.0) |
 |--------|-------------------|-----------------|
 | Inner literal speedup | **87-3154x** | ✅ Achieved |
 | Case-insensitive speedup | **263x** | ✅ Achieved |
 | Alternation speedup | **242x** | ✅ Achieved |
 | Suffix alternation speedup | **34-385x** | ✅ Achieved |
+| Small string perf | **1.4-20x faster** | ✅ Achieved |
 | Reverse search | **Yes (4 strategies)** | ✅ Achieved |
 | OnePass DFA | **Yes** | ✅ Achieved |
 | Teddy SIMD prefilter | **Yes** | ✅ Achieved |
 | BoundedBacktracker | **Yes** | ✅ Achieved |
+| CharClassSearcher | **Yes (23x, 2x vs Rust)** | ✅ Achieved |
 | ARM NEON SIMD | No | Planned |
 | Look-around | No | Planned |
 
@@ -30,7 +32,7 @@ Build a **production-ready, high-performance regex engine** for Go that matches 
 ## Release Strategy
 
 ```
-v0.8.20 (Current) ✅ → ReverseSuffixSet for multi-suffix patterns (34-385x faster)
+v0.8.22 (Current) ✅ → Small string optimization (1.4-20x faster)
          ↓
 v0.9.x → Beta testing, API stabilization
          ↓
@@ -52,6 +54,8 @@ v1.0.0 STABLE → Production release with API stability guarantee
 - ✅ **v0.8.14-18**: GoAWK integration fixes, Teddy prefilter, BoundedBacktracker
 - ✅ **v0.8.19**: FindAll ReverseSuffix optimization (87x faster)
 - ✅ **v0.8.20**: ReverseSuffixSet for multi-suffix patterns (34-385x faster)
+- ✅ **v0.8.21**: CharClassSearcher (23x faster, 2x faster than Rust!)
+- ✅ **v0.8.22**: Small string optimization (1.4-20x faster on ~44B inputs)
 
 ---
 

--- a/meta/config.go
+++ b/meta/config.go
@@ -83,7 +83,7 @@ func DefaultConfig() Config {
 		EnablePrefilter:      true,
 		MaxDFAStates:         10000,
 		DeterminizationLimit: 1000,
-		MinLiteralLen:        2,
+		MinLiteralLen:        1, // Allow single-byte prefilters (memchr) like Rust
 		MaxLiterals:          64,
 		MaxRecursionDepth:    100,
 	}

--- a/regex_test.go
+++ b/regex_test.go
@@ -438,6 +438,8 @@ func BenchmarkFindIndex(b *testing.B) {
 		{"literal", "fox", []byte("the quick brown fox jumps")},
 		{"digit", `\d+`, []byte("abc123def456")},
 		{"word", `\w+`, []byte("hello, world!")},
+		// GoAWK pattern (Ben Hoyt) - critical for small string performance
+		{"goawk_char_range", `j[a-z]+p`, []byte("The quick brown fox jumps over the lazy dog")},
 	}
 
 	for _, tt := range tests {
@@ -559,6 +561,7 @@ func BenchmarkReplaceAllFunc(b *testing.B) {
 }
 
 // BenchmarkMatchString benchmarks MatchString (string input)
+// Includes patterns from GoAWK benchmarks (Ben Hoyt) for regression testing.
 func BenchmarkMatchString(b *testing.B) {
 	tests := []struct {
 		name    string
@@ -569,6 +572,10 @@ func BenchmarkMatchString(b *testing.B) {
 		{"digit", `\d+`, "abc123def"},
 		{"anchored", `^hello`, "hello world"},
 		{"suffix", `\.txt$`, "document.txt"},
+		// GoAWK patterns (Ben Hoyt) - critical for small string performance
+		{"goawk_char_range", `j[a-z]+p`, "The quick brown fox jumps over the lazy dog"},
+		{"goawk_word", `\w+`, "hello world 123"},
+		{"goawk_lowercase", `[a-z]+`, "Hello World Test"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Addresses performance issues reported in issue #29 where coregex was 2-6x slower than stdlib on small inputs (~44 bytes) with patterns like `j[a-z]+p`, `\d+`, `\w+`.

**Key optimizations:**

1. **Zero-allocation string-to-bytes conversion**
   - Added `stringToBytes()` using `unsafe.Slice` (like Rust's `as_bytes()`)
   - All `*String` methods now have 0 allocations for input conversion
   - `MatchString`: 48B/op → 0B/op

2. **BoundedBacktracker for small NFA patterns**
   - BoundedBacktracker uses O(1) generation-based reset vs PikeVM's thread queues
   - 2-3x faster on small inputs
   - Added `canMatchEmpty` detection to avoid greedy semantics bugs

3. **Prefilter integration in NFA path**
   - `isMatchNFA` and `findIndicesNFA` now use prefilter for skip-ahead
   - Combined with BoundedBacktracker for optimal small-string perf

## Performance Results

| Pattern | stdlib | coregex | Speedup |
|---------|--------|---------|---------|
| `j[a-z]+p` (MatchString) | 357ns | 253ns | **1.4x** |
| `\d+` (MatchString) | 1.13µs | 57ns | **20x** |
| `\w+` (MatchString) | 1.05µs | 58ns | **18x** |
| `[a-z]+` (MatchString) | 1.02µs | 63ns | **16x** |
| Split | 1.74µs | 992ns | **1.75x** |
| Gsub | 1.58µs | 1.23µs | **1.28x** |

## Test Plan

- [x] All existing tests pass
- [x] Added `canMatchEmpty` correctness tests
- [x] Added GoAWK benchmark patterns for regression testing
- [x] golangci-lint passes
- [x] No regressions on existing benchmarks

Closes #47

Related to #29 (detailed analysis will be posted separately)