### PR TITLE
fix: CharClassSearcher ASCII-only check (>127 not >255)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ benchmark/baselines/
 
 # Local assets (screenshots, diagrams for docs)
 assets/
+regex-bench/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Unicode char class bug** - CharClassSearcher incorrectly handled runes 128-255
+  - `[föd]+` on "fööd" returned "f" instead of "fööd"
+  - Root cause: check was `> 255` but runes like ö (code point 246) are multi-byte in UTF-8 (0xC3 0xB6)
+  - Fix: changed to `> 127` to only allow true ASCII (0-127) for byte lookup table
+  - Found by: Ben Hoyt (GoAWK integration testing)
+
 ### Planned
 - Look-around assertions
 - ARM NEON SIMD support (waiting for Go 1.26 native SIMD)

--- a/nfa/charclass_extract.go
+++ b/nfa/charclass_extract.go
@@ -50,9 +50,11 @@ func ExtractCharClassRanges(re *syntax.Regexp) [][2]byte {
 	for i := 0; i < len(sub.Rune); i += 2 {
 		lo, hi := sub.Rune[i], sub.Rune[i+1]
 
-		// Only support ASCII byte ranges
-		if lo > 255 || hi > 255 {
-			return nil // Unicode - not supported
+		// Only support ASCII byte ranges (0-127)
+		// Runes > 127 require multi-byte UTF-8 encoding which CharClassSearcher can't handle
+		// For example: ö = code point 246, but UTF-8 = 0xC3 0xB6 (2 bytes)
+		if lo > 127 || hi > 127 {
+			return nil // Non-ASCII - not supported by byte lookup table
 		}
 
 		ranges = append(ranges, [2]byte{byte(lo), byte(hi)})

--- a/nfa/charclass_extract_test.go
+++ b/nfa/charclass_extract_test.go
@@ -21,14 +21,25 @@ func TestExtractCharClassRanges(t *testing.T) {
 		{`[a-zA-Z0-9_]+`, 4},
 		{`[abc]+`, 1}, // Go optimizes consecutive chars [a-c] to single range
 
-		// Not supported
-		{`abc`, -1},          // No quantifier
-		{`[a-z]`, -1},        // No quantifier (need + or *)
-		{`[a-z]?`, -1},       // ? not supported
-		{`a+`, -1},           // Single char, not char class
+		// Not supported - no quantifier
+		{`abc`, -1},    // No quantifier
+		{`[a-z]`, -1},  // No quantifier (need + or *)
+		{`[a-z]?`, -1}, // ? not supported
+		{`a+`, -1},     // Single char, not char class
+
+		// Not supported - complex patterns
 		{`[a-z]+[0-9]+`, -1}, // Concatenation
 		{`^[a-z]+`, -1},      // Anchor
 		{`[a-z]+$`, -1},      // Anchor
+
+		// Not supported - Unicode (rune > 127 requires multi-byte UTF-8)
+		// This is critical: ö has code point 246 but UTF-8 encoding is 0xC3 0xB6 (2 bytes)
+		// CharClassSearcher's 256-byte lookup table can't handle multi-byte UTF-8
+		{`[föd]+`, -1}, // Mixed ASCII + Unicode
+		{`[äöü]+`, -1}, // All Unicode (Latin-1 Supplement)
+		{`[α-ω]+`, -1}, // Greek letters
+		{`[日本語]+`, -1}, // CJK characters
+		{`[ö]+`, -1},   // Single Unicode char
 	}
 
 	for _, tt := range tests {

--- a/regex_unicode_test.go
+++ b/regex_unicode_test.go
@@ -1,0 +1,105 @@
+package coregex
+
+import (
+	"regexp"
+	"testing"
+)
+
+// TestUnicodeCharClass tests that Unicode character classes work correctly.
+// This is a regression test for the bug where CharClassSearcher was incorrectly
+// used for patterns with runes > 127 (like ö = code point 246).
+// The issue: ö has code point 246 which is < 255, but UTF-8 encoding is
+// 0xC3 0xB6 (2 bytes), so byte lookup table doesn't work.
+func TestUnicodeCharClass(t *testing.T) {
+	tests := []struct {
+		pattern string
+		text    string
+		want    string // expected match, "" for no match
+	}{
+		// Mixed ASCII + Unicode
+		{`[föd]+`, "fööd", "fööd"},
+		{`[föd]+`, "food", "f"},     // 'o' is not in [föd], so only 'f' matches
+		{`[food]+`, "food", "food"}, // ASCII-only class for comparison
+		{`[föd]+`, "hello fööd world", "fööd"},
+
+		// All Unicode
+		{`[äöü]+`, "äöü", "äöü"},
+		{`[äöü]+`, "hello äöü world", "äöü"},
+		{`[äöü]+`, "abc", ""}, // no match
+
+		// Unicode literal (should work via different code path)
+		{`ö+`, "öööö", "öööö"},
+		{`ö+`, "xöööy", "ööö"},
+
+		// Alternation with Unicode (different code path)
+		{`(ö|a)+`, "öaöa", "öaöa"},
+		{`(ä|ö|ü)+`, "äöü", "äöü"},
+
+		// ASCII patterns should still work
+		{`[a-z]+`, "hello", "hello"},
+		{`[a-z]+`, "HELLO", ""}, // no match
+		{`[\w]+`, "hello123", "hello123"},
+
+		// Edge case: ASCII text with Unicode pattern
+		{`[äöü]+`, "hello", ""}, // no match
+
+		// Edge case: Unicode text with ASCII pattern
+		{`[a-z]+`, "café", "caf"}, // matches only ASCII part
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern+"_"+tt.text, func(t *testing.T) {
+			re := MustCompile(tt.pattern)
+			got := re.FindString(tt.text)
+			if got != tt.want {
+				t.Errorf("coregex.FindString(%q, %q) = %q, want %q",
+					tt.pattern, tt.text, got, tt.want)
+			}
+
+			// Verify against stdlib
+			reStd := regexp.MustCompile(tt.pattern)
+			gotStd := reStd.FindString(tt.text)
+			if got != gotStd {
+				t.Errorf("coregex.FindString(%q, %q) = %q, stdlib = %q (mismatch!)",
+					tt.pattern, tt.text, got, gotStd)
+			}
+		})
+	}
+}
+
+// TestUnicodeCharClassFindIndex tests that match positions are correct for Unicode.
+func TestUnicodeCharClassFindIndex(t *testing.T) {
+	tests := []struct {
+		pattern   string
+		text      string
+		wantStart int
+		wantEnd   int
+	}{
+		// "絵 fööd y" - 絵 is 3 bytes, space is 1, fööd is 6 bytes (f=1, ö=2, ö=2, d=1)
+		{`[föd]+`, "絵 fööd y", 4, 10}, // start=4 (after "絵 "), end=10 (length 6)
+		{`[äöü]+`, "test äöü end", 5, 11},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern, func(t *testing.T) {
+			re := MustCompile(tt.pattern)
+			idx := re.FindStringIndex(tt.text)
+			if idx == nil {
+				t.Fatalf("coregex.FindStringIndex(%q, %q) = nil, want [%d, %d]",
+					tt.pattern, tt.text, tt.wantStart, tt.wantEnd)
+			}
+			if idx[0] != tt.wantStart || idx[1] != tt.wantEnd {
+				t.Errorf("coregex.FindStringIndex(%q, %q) = [%d, %d], want [%d, %d]",
+					tt.pattern, tt.text, idx[0], idx[1], tt.wantStart, tt.wantEnd)
+			}
+
+			// Verify against stdlib
+			reStd := regexp.MustCompile(tt.pattern)
+			idxStd := reStd.FindStringIndex(tt.text)
+			if len(idxStd) != 2 || idx[0] != idxStd[0] || idx[1] != idxStd[1] {
+				t.Errorf("coregex vs stdlib mismatch: coregex=[%d,%d], stdlib=%v",
+					idx[0], idx[1], idxStd)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes Unicode char class bug where patterns like `[föd]+` incorrectly used CharClassSearcher.

**Root cause**: The check was `lo > 255` but runes 128-255 (like ö=246) are multi-byte in UTF-8 (ö = 0xC3 0xB6), so the 256-byte lookup table doesn't work correctly.

**Fix**: Changed to `lo > 127` to only allow true ASCII (0-127).

## Test Case

```go
// Before fix: match("絵 fööd y", /[föd]+/) returned RLENGTH=1 (only 'f')
// After fix: returns RLENGTH=6 (correctly matches "fööd")
```

## Changes

- `nfa/charclass_extract.go`: ASCII check changed from >255 to >127
- `nfa/charclass_extract_test.go`: Added Unicode rejection tests  
- `regex_unicode_test.go`: New end-to-end Unicode tests with stdlib comparison
- `CHANGELOG.md`: Documented the fix

## Credit

Found by: Ben Hoyt (GoAWK integration testing)