### PR TITLE
Update coregex testing reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Pure Go fallback on other architectures.
 
 ## Battle-Tested
 
-coregex was [tested in GoAWK](https://github.com/benhoyt/goawk/pull/264) by Ben Hoyt. This real-world testing uncovered 15+ edge cases that synthetic benchmarks missed.
+coregex was [tested in GoAWK](https://github.com/benhoyt/goawk/pull/264). This real-world testing uncovered 15+ edge cases that synthetic benchmarks missed.
 
 **We need more testers!** If you have a project using `regexp`, try coregex and [report issues](https://github.com/coregx/coregex/issues).
 


### PR DESCRIPTION
Correcting this text to clarify: coregex is not "integrated in GoAWK". Rather, I did some testing in GoAWK (in a now-closed PR).

Also, I'd prefer my name wasn't on this project.