### PR TITLE
fix: DigitPrefilter regression for complex IP patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **DigitPrefilter regression for complex patterns** (IP address validation)
+  - DigitPrefilter caused 1.3x slowdown on complex IP patterns with many alternations
+  - Root cause: High false positive rate (9x) + expensive DFA verification per candidate
+  - Solution: Added `isDigitPrefilterBeneficial()` complexity analysis
+  - Thresholds: >50 NFA states, >8 alternation branches, >2 nesting depth → disable prefilter
+  - Complex IP patterns now use `UseBoth` (lazy DFA without prefilter)
+  - **Result**: 1.3x slower → **3.5x faster** than stdlib
+  - Reference: Rust regex-automata prefilter heuristics
+
+### Changed
+- **DigitPrefilter scope refined**: Now applies only to simple digit-lead patterns
+  - Version patterns (`\d+\.\d+\.\d+`) — still uses DigitPrefilter (40-2500x speedup)
+  - Complex IP validation — uses LazyDFA strategy (3.5x speedup)
+- **Removed outdated TODO comments**: Cleaned up 4 obsolete TODOs in dfa/lazy and prefilter
+
 ### Planned
 - Look-around assertions
 - ARM NEON SIMD support (waiting for Go 1.26 native SIMD)

--- a/README.md
+++ b/README.md
@@ -86,12 +86,12 @@ coregex automatically selects the optimal engine:
 | Strategy | Pattern Type | Speedup |
 |----------|--------------|---------|
 | ReverseInner | `.*keyword.*` | 1000-3000x |
-| DigitPrefilter | IP patterns `\d+\.\d+\.\d+\.\d+` | 40-2500x |
+| DigitPrefilter | Simple digit-lead `\d+\.\d+\.\d+` | 40-2500x |
 | ReverseSuffix | `.*\.txt` | 100-400x |
 | AhoCorasick | `a\|b\|c\|...\|z` (>8 patterns) | 75-113x |
 | CharClassSearcher | `[\w]+`, `\d+` | 20-25x |
 | Teddy | `foo\|bar\|baz` (2-8 patterns) | 15-240x |
-| LazyDFA | Complex with literals | 10-50x |
+| LazyDFA | Complex patterns, IP validation | 3-50x |
 | OnePass | Anchored captures | 10x |
 | BoundedBacktracker | Small patterns | 2-5x |
 

--- a/dfa/lazy/builder.go
+++ b/dfa/lazy/builder.go
@@ -127,13 +127,11 @@ func (b *Builder) Build() (*DFA, error) {
 // buildPrefilter extracts literals from the NFA and builds a prefilter.
 // Returns nil if no suitable prefilter can be constructed.
 //
-// For MVP, prefilter extraction from NFA is not implemented.
-// Future enhancement: Walk NFA to extract literal sequences.
+// buildPrefilter returns nil - literal extraction is handled by meta/ package.
+// The meta.Engine extracts literals from AST before DFA construction.
 func (b *Builder) buildPrefilter() prefilter.Prefilter {
-	// TODO: Extract literals from NFA
-	// For now, we don't have NFA → syntax.Regexp conversion
-	// This will be implemented when we add regex compilation
-	// For MVP, prefilter is optional
+	// Literal extraction happens in meta/ via literal.ExtractFromAST()
+	// DFA builder doesn't need independent prefilter construction
 
 	// Placeholder: extract from pattern if available
 	// In a full implementation, we would:
@@ -569,12 +567,9 @@ func ExtractPrefilter(pattern string) (prefilter.Prefilter, error) {
 		return nil, err
 	}
 
-	// TODO: Extract literals from NFA
-	// For now, return (nil, nil) indicating no prefilter (not an error)
-	// Full implementation requires NFA → AST conversion or literal extraction from NFA
-	_ = nfaObj // Suppress unused variable warning
-
-	// No prefilter available - this is not an error condition
+	// Literal extraction is handled by meta/ package via literal.ExtractFromAST()
+	// This function returns nil prefilter - meta.Engine manages prefilters
+	_ = nfaObj // NFA used for state construction, not literal extraction
 	// Returning (nil, nil) is intentional and documented
 	//nolint:nilnil // nil prefilter with nil error indicates "no prefilter available" (not an error)
 	return nil, nil

--- a/prefilter/prefilter.go
+++ b/prefilter/prefilter.go
@@ -233,7 +233,7 @@ func (b *Builder) Build() Prefilter {
 //     - len==1 → MemchrPrefilter (single byte search)
 //     - len>1 → MemmemPrefilter (substring search)
 //  4. If 2-8 literals and minLen≥3 → TeddyPrefilter (SIMD multi-pattern)
-//  5. If many/short literals → nil (TODO: AhoCorasickPrefilter)
+//  5. If many/short literals → nil (Aho-Corasick handled via meta.UseAhoCorasick strategy)
 //
 // Returns nil if no effective prefilter can be constructed.
 func selectPrefilter(prefixes, suffixes *literal.Seq) Prefilter {
@@ -266,9 +266,9 @@ func selectPrefilter(prefixes, suffixes *literal.Seq) Prefilter {
 		return newTeddy(seq)
 	}
 
-	// Many literals or short literals
-	// TODO: implement Aho-Corasick (Phase 3)
-	// Aho-Corasick handles many patterns efficiently via automaton
+	// Many literals or short literals - return nil
+	// Aho-Corasick is handled at strategy level (meta.UseAhoCorasick)
+	// for >8 literal alternations, not as a prefilter
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Fix DigitPrefilter causing 1.3x slowdown on complex IP patterns
- Add `isDigitPrefilterBeneficial()` complexity analysis based on Rust regex heuristics
- Complex patterns (>50 NFA states, >8 alternation branches) now use `UseBoth` strategy

## Changes
| File | Change |
|------|--------|
| `meta/strategy.go` | +140 lines: complexity analysis functions |
| `meta/strategy_test.go` | +171 lines: regression tests |
| `README.md` | Update strategy table |
| `CHANGELOG.md` | Document fix |
| `dfa/lazy/builder.go` | Remove 2 obsolete TODOs |
| `prefilter/prefilter.go` | Remove 2 obsolete TODOs |

## Benchmark Result
```
IP pattern (6MB input):
Before: stdlib 478ms → coregex 625ms (1.3x SLOWER ❌)
After:  stdlib 478ms → coregex 137ms (3.5x FASTER ✅)
```

## Test Plan
- [x] All existing tests pass
- [x] New `TestIPPatternStrategy` verifies IP uses UseBoth
- [x] New `TestDigitPrefilterComplexityAnalysis` tests metrics
- [x] New `TestIsDigitPrefilterBeneficial` tests thresholds
- [x] golangci-lint: 0 issues
- [x] Coverage: 86.7%