### PR TITLE
fix: DigitPrefilter adaptive switching for high FP scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.9.1] - 2026-01-05
+
+### Fixed
+- **DigitPrefilter adaptive switching** for high false-positive scenarios
+  - Problem: DigitPrefilter was slow on dense digit data (many consecutive FPs)
+  - Solution: Runtime adaptive switching - after 64 consecutive false positives, switch to DFA
+  - Based on Rust regex insight: "prefilter with high FP rate makes search slower"
+  - Sparse data: prefilter remains fast (100-3000x speedup via SIMD skip)
+  - Dense data: adaptively switches to lazy DFA (3-5x speedup vs stdlib)
+  - New stat: `Stats.PrefilterAbandoned` tracks adaptive switching events
+  - New constant: `digitPrefilterAdaptiveThreshold = 64`
+
+### Performance (IP regex benchmarks)
+
+| Scenario | stdlib | coregex | Speedup |
+|----------|--------|---------|---------|
+| Sparse 64KB | 833 µs | 2.8 µs | **300x** |
+| Dense 64KB | 8.5 µs | 2.4 µs | **3.5x** |
+| No IPs 1MB | 60.7 ms | 19.8 µs | **3000x** |
+
+---
+
 ## [0.9.0] - 2026-01-05
 
 ### Added

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -91,6 +91,9 @@ type Stats struct {
 	// PrefilterMisses counts prefilter candidates that didn't match
 	PrefilterMisses uint64
 
+	// PrefilterAbandoned counts times prefilter was abandoned due to high FP rate
+	PrefilterAbandoned uint64
+
 	// DFACacheFull counts times DFA fell back to NFA due to cache full
 	DFACacheFull uint64
 }
@@ -1881,6 +1884,18 @@ func (e *Engine) FindAllSubmatch(haystack []byte, n int) []*MatchWithCaptures {
 	return matches
 }
 
+// digitPrefilterAdaptiveThreshold is the number of consecutive false positives
+// (digit positions that don't lead to matches) before switching to DFA-only mode.
+// This implements runtime adaptive switching based on Rust regex's insight:
+// "if a prefilter has a high false positive rate and produces lots of candidates,
+// then a prefilter can overall make a regex search slower."
+//
+// Value rationale:
+//   - Too low (e.g., 8): May switch prematurely on sparse data
+//   - Too high (e.g., 256): Wastes time on dense data with many FPs
+//   - 64: Good balance - gives prefilter fair chance while limiting overhead
+const digitPrefilterAdaptiveThreshold = 64
+
 // findDigitPrefilter searches using SIMD digit scanning + DFA verification.
 // Used for digit-lead patterns like IP addresses where literal extraction fails
 // but all alternation branches must start with a digit.
@@ -1889,10 +1904,11 @@ func (e *Engine) FindAllSubmatch(haystack []byte, n int) []*MatchWithCaptures {
 //  1. Use SIMD to find next digit position in haystack
 //  2. Verify match at digit position using lazy DFA + PikeVM
 //  3. If no match, continue from digit position + 1
+//  4. ADAPTIVE: If too many consecutive FPs, switch to DFA-only mode
 //
 // Performance:
-//   - Skips non-digit regions with SIMD (15-20x faster than byte-by-byte)
-//   - DFA verification is O(m) where m is pattern length
+//   - Sparse data: Skips non-digit regions with SIMD (15-20x faster)
+//   - Dense data: Adaptively switches to DFA when FP rate is high
 //   - Total: O(n) for scan + O(k*m) for k digit candidates
 func (e *Engine) findDigitPrefilter(haystack []byte) *Match {
 	if e.digitPrefilter == nil {
@@ -1901,8 +1917,16 @@ func (e *Engine) findDigitPrefilter(haystack []byte) *Match {
 
 	e.stats.PrefilterHits++ // Count prefilter usage
 	pos := 0
+	consecutiveFPs := 0 // Track consecutive false positives
 
 	for pos < len(haystack) {
+		// ADAPTIVE: If too many consecutive FPs, abandon prefilter and use DFA directly
+		// This prevents pathological slowdown on dense digit data (like IP-heavy text)
+		if consecutiveFPs >= digitPrefilterAdaptiveThreshold {
+			e.stats.PrefilterAbandoned++
+			return e.findAdaptiveAt(haystack, pos)
+		}
+
 		// Use SIMD to find next digit position
 		digitPos := e.digitPrefilter.Find(haystack, pos)
 		if digitPos < 0 {
@@ -1920,6 +1944,8 @@ func (e *Engine) findDigitPrefilter(haystack []byte) *Match {
 					return NewMatch(start, end, haystack)
 				}
 			}
+			// DFA rejected - count as false positive
+			consecutiveFPs++
 		} else {
 			// No DFA - use PikeVM directly
 			e.stats.NFASearches++
@@ -1927,6 +1953,8 @@ func (e *Engine) findDigitPrefilter(haystack []byte) *Match {
 			if found {
 				return NewMatch(start, end, haystack)
 			}
+			// NFA rejected - count as false positive
+			consecutiveFPs++
 		}
 
 		// No match at this digit position, continue searching
@@ -1937,6 +1965,7 @@ func (e *Engine) findDigitPrefilter(haystack []byte) *Match {
 }
 
 // findDigitPrefilterAt searches using digit prefilter starting at position 'at'.
+// Uses adaptive switching like findDigitPrefilter.
 func (e *Engine) findDigitPrefilterAt(haystack []byte, at int) *Match {
 	if e.digitPrefilter == nil || at >= len(haystack) {
 		return e.findNFAAt(haystack, at)
@@ -1944,8 +1973,15 @@ func (e *Engine) findDigitPrefilterAt(haystack []byte, at int) *Match {
 
 	e.stats.PrefilterHits++
 	pos := at
+	consecutiveFPs := 0
 
 	for pos < len(haystack) {
+		// ADAPTIVE: Switch to DFA if too many consecutive FPs
+		if consecutiveFPs >= digitPrefilterAdaptiveThreshold {
+			e.stats.PrefilterAbandoned++
+			return e.findAdaptiveAt(haystack, pos)
+		}
+
 		digitPos := e.digitPrefilter.Find(haystack, pos)
 		if digitPos < 0 {
 			return nil
@@ -1960,12 +1996,14 @@ func (e *Engine) findDigitPrefilterAt(haystack []byte, at int) *Match {
 					return NewMatch(start, end, haystack)
 				}
 			}
+			consecutiveFPs++
 		} else {
 			e.stats.NFASearches++
 			start, end, found := e.pikevm.SearchAt(haystack, digitPos)
 			if found {
 				return NewMatch(start, end, haystack)
 			}
+			consecutiveFPs++
 		}
 
 		pos = digitPos + 1
@@ -1976,6 +2014,7 @@ func (e *Engine) findDigitPrefilterAt(haystack []byte, at int) *Match {
 
 // isMatchDigitPrefilter checks for match using digit prefilter.
 // Optimized for boolean matching with early termination.
+// Uses adaptive switching like findDigitPrefilter.
 func (e *Engine) isMatchDigitPrefilter(haystack []byte) bool {
 	if e.digitPrefilter == nil {
 		return e.isMatchNFA(haystack)
@@ -1983,8 +2022,15 @@ func (e *Engine) isMatchDigitPrefilter(haystack []byte) bool {
 
 	e.stats.PrefilterHits++
 	pos := 0
+	consecutiveFPs := 0
 
 	for pos < len(haystack) {
+		// ADAPTIVE: Switch to DFA if too many consecutive FPs
+		if consecutiveFPs >= digitPrefilterAdaptiveThreshold {
+			e.stats.PrefilterAbandoned++
+			return e.isMatchAdaptive(haystack[pos:])
+		}
+
 		digitPos := e.digitPrefilter.Find(haystack, pos)
 		if digitPos < 0 {
 			return false // No more digits
@@ -1997,12 +2043,14 @@ func (e *Engine) isMatchDigitPrefilter(haystack []byte) bool {
 			if e.dfa.FindAt(haystack, digitPos) != -1 {
 				return true
 			}
+			consecutiveFPs++
 		} else {
 			e.stats.NFASearches++
 			_, _, found := e.pikevm.SearchAt(haystack, digitPos)
 			if found {
 				return true
 			}
+			consecutiveFPs++
 		}
 
 		pos = digitPos + 1
@@ -2012,6 +2060,7 @@ func (e *Engine) isMatchDigitPrefilter(haystack []byte) bool {
 }
 
 // findIndicesDigitPrefilter returns indices using digit prefilter - zero alloc.
+// Uses adaptive switching like findDigitPrefilter.
 func (e *Engine) findIndicesDigitPrefilter(haystack []byte) (int, int, bool) {
 	if e.digitPrefilter == nil {
 		return e.findIndicesNFA(haystack)
@@ -2019,8 +2068,15 @@ func (e *Engine) findIndicesDigitPrefilter(haystack []byte) (int, int, bool) {
 
 	e.stats.PrefilterHits++
 	pos := 0
+	consecutiveFPs := 0
 
 	for pos < len(haystack) {
+		// ADAPTIVE: Switch to DFA if too many consecutive FPs
+		if consecutiveFPs >= digitPrefilterAdaptiveThreshold {
+			e.stats.PrefilterAbandoned++
+			return e.findIndicesAdaptiveAt(haystack, pos)
+		}
+
 		digitPos := e.digitPrefilter.Find(haystack, pos)
 		if digitPos < 0 {
 			return -1, -1, false
@@ -2035,12 +2091,14 @@ func (e *Engine) findIndicesDigitPrefilter(haystack []byte) (int, int, bool) {
 					return start, end, true
 				}
 			}
+			consecutiveFPs++
 		} else {
 			e.stats.NFASearches++
 			start, end, found := e.pikevm.SearchAt(haystack, digitPos)
 			if found {
 				return start, end, true
 			}
+			consecutiveFPs++
 		}
 
 		pos = digitPos + 1
@@ -2050,6 +2108,7 @@ func (e *Engine) findIndicesDigitPrefilter(haystack []byte) (int, int, bool) {
 }
 
 // findIndicesDigitPrefilterAt returns indices starting at position 'at' - zero alloc.
+// Uses adaptive switching like findDigitPrefilter.
 func (e *Engine) findIndicesDigitPrefilterAt(haystack []byte, at int) (int, int, bool) {
 	if e.digitPrefilter == nil || at >= len(haystack) {
 		return e.findIndicesNFAAt(haystack, at)
@@ -2057,8 +2116,15 @@ func (e *Engine) findIndicesDigitPrefilterAt(haystack []byte, at int) (int, int,
 
 	e.stats.PrefilterHits++
 	pos := at
+	consecutiveFPs := 0
 
 	for pos < len(haystack) {
+		// ADAPTIVE: Switch to DFA if too many consecutive FPs
+		if consecutiveFPs >= digitPrefilterAdaptiveThreshold {
+			e.stats.PrefilterAbandoned++
+			return e.findIndicesAdaptiveAt(haystack, pos)
+		}
+
 		digitPos := e.digitPrefilter.Find(haystack, pos)
 		if digitPos < 0 {
 			return -1, -1, false
@@ -2073,12 +2139,14 @@ func (e *Engine) findIndicesDigitPrefilterAt(haystack []byte, at int) (int, int,
 					return start, end, true
 				}
 			}
+			consecutiveFPs++
 		} else {
 			e.stats.NFASearches++
 			start, end, found := e.pikevm.SearchAt(haystack, digitPos)
 			if found {
 				return start, end, true
 			}
+			consecutiveFPs++
 		}
 
 		pos = digitPos + 1


### PR DESCRIPTION
## Summary
Runtime adaptive switching prevents pathological slowdown on dense digit data.

**Problem**: DigitPrefilter was fast on sparse data but slow on dense digit data (many consecutive false positives → expensive DFA verification overhead).

**Solution**: After 64 consecutive false positives, adaptively switch from prefilter to lazy DFA scan.

Based on Rust regex insight:
> "if a prefilter has a high false positive rate and produces lots of candidates, then a prefilter can overall make a regex search slower"

## Performance Results

| Scenario | stdlib | coregex | Speedup |
|----------|--------|---------|---------|
| Sparse 64KB | 833 µs | 2.8 µs | **300x** |
| Sparse 6MB | 347 µs | 2.5 µs | **140x** |
| Dense 64KB | 8.5 µs | 2.4 µs | **3.5x** |
| Dense 1MB | 11.7 µs | 2.3 µs | **5x** |
| No IPs 64KB | 3.9 ms | 1.3 µs | **3000x** |
| No IPs 1MB | 60.7 ms | 19.8 µs | **3000x** |

**No regression on any scenario!**

## Changes
| File | Change |
|------|--------|
| `meta/meta.go` | +`digitPrefilterAdaptiveThreshold` constant (64) |
| `meta/meta.go` | +FP tracking in all DigitPrefilter search functions |
| `meta/meta.go` | +`Stats.PrefilterAbandoned` field |
| `meta/digit_prefilter_integration_test.go` | +Adaptive switching tests |

## Test Plan
- [x] All existing tests pass
- [x] New `TestDigitPrefilterAdaptiveSwitching` verifies correctness
- [x] IP regex benchmarks show no regression
- [x] golangci-lint: 0 issues
- [x] Race detector: passed