### PR TITLE
perf: fix FindAll 600x regression for anchored patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Performance: FindAll 600x faster for anchored patterns on large inputs**
+  - Bug: `FindAll("^HTTP/[12]\.[01]", 6MB)` took 346µs instead of <1µs
+  - Root cause: Allocation heuristic `make([][2]int, 0, len(haystack)/100+1)` created 1MB buffer for 1 match
+  - Fix: Smart allocation - anchored patterns use cap=1, others capped at 256
+  - Result: Now matches stdlib performance (~500ns for anchored patterns)
+  - Added `Engine.IsStartAnchored()` method for allocation optimization
+
 ### Planned
 - Look-around assertions
 - ARM NEON SIMD support (waiting for Go 1.26 native SIMD)


### PR DESCRIPTION
## Summary

- Fix **600x performance regression** for `FindAll` on anchored patterns with large inputs
- Anchored patterns (`^...`) now use `cap=1` allocation (max 1 match possible)
- Non-anchored patterns capped at 256 (was unbounded, causing 1MB allocation for 6MB input)
- Added `Engine.IsStartAnchored()` method for allocation optimization

## Problem

`FindAll("^HTTP/[12]\.[01]", 6MB_input)` took **346µs** instead of **<1µs**

**Root cause:** Allocation heuristic `make([][2]int, 0, len(haystack)/100+1)` created ~1MB buffer (62,915 capacity) for a pattern that matches at most once.

## Benchmarks (6MB input, 1 match)

| | Before | After |
|---|---|---|
| coregex | 346µs | 567ns |
| stdlib | ~0µs | 566ns |
| **Ratio** | 600x slower | **Equal** |

## Changes

- `meta/meta.go`: Smart allocation in `findAllIndicesLoop`, new `IsStartAnchored()` method
- `regex.go`: Smart allocation in `FindAll`
- `CHANGELOG.md`: Document fix

## Test plan

- [x] All tests pass (`go test ./...`)
- [x] Linter passes (`golangci-lint run`)
- [x] Benchmarks verified locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)