### PR TITLE
fix: ReverseSuffix whitelist includes CharClass Plus patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.10.10] - 2026-01-15
+
+### Fixed
+- **ReverseSuffix whitelist includes CharClass Plus** - Performance regression fix
+  - Bug: `[^\s]+\.txt` pattern caused extreme slowdown (266ms/MB instead of µs)
+  - Root cause: `isSafeForReverseSuffix` only recognized `.*` and `.+` wildcards
+  - Fix: CharClass Plus patterns (`[^\s]+`, `[\w]+`) now qualify for reverse suffix optimization
+  - Result: `suffix_find` pattern now completes in 398µs (was timing out)
+
+---
+
 ## [0.10.9] - 2026-01-15
 
 ### Added


### PR DESCRIPTION
## Summary
Fix performance regression where `[^\s]+\.txt` pattern caused extreme benchmark to hang.

## Problem
- `isSafeForReverseSuffix` only recognized `.*` and `.+` wildcards
- CharClass Plus patterns like `[^\s]+` were not recognized as safe wildcards
- Result: Pattern fell back to slow path (266ms/MB instead of µs)

## Solution
- Add CharClass Plus patterns to whitelist of safe wildcard patterns
- Now patterns like `[^\s]+\.txt`, `[\w]+\.go` use ReverseSuffix optimization

## Testing
- Added `TestReverseSuffix_CharClassPlus` test
- Local benchmark: `suffix_find` now completes in 398µs (was timing out)
- All existing tests pass

## Impact
- Fixes extreme benchmark CI hang
- No regressions in other patterns