### PR TITLE
perf: UseMultilineReverseSuffix uses DFA instead of PikeVM (#99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.11.2] - 2026-01-16
+
+### Changed
+- **UseMultilineReverseSuffix: DFA verification instead of PikeVM** (Issue #99)
+  - Replaced O(n*m) PikeVM verification with O(n) DFA verification
+  - Uses `lazy.DFA.SearchAtAnchored()` for linear-time anchored matching
+  - No-match cases: **10-131x faster** (microseconds vs milliseconds)
+  - Large input (6MB): expected **10-30x improvement** vs previous PikeVM approach
+  - Research: Rust hybrid DFA also uses DFA (not per-state acceleration) for verification
+
+### Technical Details
+- `MultilineReverseSuffixSearcher.forwardDFA` replaces `pikevm` field
+- `lazy.CompileWithConfig()` creates forward DFA with config
+- DFA state construction amortized across multiple searches
+
+---
+
 ## [0.11.1] - 2026-01-16
 
 ### Added


### PR DESCRIPTION
## Summary

Replace O(n*m) PikeVM verification with O(n) DFA verification for multiline suffix patterns.

**Issue**: #99 (Rust regex 84x faster on `(?m)^/.*\.php`)

### Root Cause (from research)

The 84x performance gap was NOT due to missing DFA state acceleration. Research revealed:

1. **Rust hybrid DFA does NOT use per-state acceleration** — only dense DFA does
2. **coregex already has partial acceleration** in `dfa/lazy/`
3. **Real bottleneck**: `MultilineReverseSuffixSearcher` used PikeVM (O(n*m)) instead of DFA (O(n))

### Changes

- `MultilineReverseSuffixSearcher.forwardDFA` replaces `pikevm` field
- Uses `lazy.DFA.SearchAtAnchored()` for linear-time anchored matching
- `lazy.CompileWithConfig()` creates forward DFA with proper config

### Performance

| Case | Before | After | Speedup |
|------|--------|-------|---------|
| No-match (2KB) | 1136 ns | 108 ns | **10.5x** |
| Long no-match | 25937 ns | 197 ns | **131x** |
| Large input (6MB) | 66 ms | ~5-10 ms | **10-30x** (expected) |

### Testing

- [x] All existing tests pass
- [x] Linter clean (golangci-lint)
- [x] No regressions on other patterns
- [ ] regex-bench CI validation (after merge)

### Technical Details

Research document: `docs/dev/research/DFA_STATE_ACCELERATION_RESEARCH.md`

Key insight from Rust code (`hybrid/search.rs`):
> The hybrid DFA search does NOT call any acceleration-related functions. It uses loop unrolling and tagged state ID checks for performance.

Fixes #99 (Phase 1)