### PR TITLE
perf: v0.11.3 prefix fast path 319-552x speedup (#99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,20 +14,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.11.3] - 2026-01-16
+
+### Changed
+- **UseMultilineReverseSuffix: Prefix verification fast path** (Issue #99)
+  - Pattern `(?m)^/.*\.php` now **319-552x faster** than stdlib (was 3.5-5.7x)
+  - Algorithm: suffix prefilter → SIMD backward scan → O(1) prefix byte check
+  - Skip-to-next-line optimization: avoids O(n²) worst case
+  - DFA fallback for complex patterns without extractable prefix
+
+### Performance (pattern `(?m)^/.*\.php` on 1KB log data)
+
+| Operation | coregex | stdlib | Speedup |
+|-----------|---------|--------|---------|
+| IsMatch | 182 ns | 100 µs | **552x** |
+| Find | 240 ns | 81 µs | **338x** |
+| CountAll | 58 µs | 18.7 ms | **319x** |
+
+### Technical Details
+- `MultilineReverseSuffixSearcher.prefixBytes` for O(1) verification
+- `SetPrefixLiterals()` extracts prefix from pattern
+- `findLineStart()` uses SIMD `bytes.LastIndexByte`
+- Skip-to-next-line: on prefix mismatch, jump to next `\n` position
+
+---
+
 ## [0.11.2] - 2026-01-16
 
 ### Changed
 - **UseMultilineReverseSuffix: DFA verification instead of PikeVM** (Issue #99)
   - Replaced O(n*m) PikeVM verification with O(n) DFA verification
   - Uses `lazy.DFA.SearchAtAnchored()` for linear-time anchored matching
-  - No-match cases: **10-131x faster** (microseconds vs milliseconds)
-  - Large input (6MB): expected **10-30x improvement** vs previous PikeVM approach
-  - Research: Rust hybrid DFA also uses DFA (not per-state acceleration) for verification
-
-### Technical Details
-- `MultilineReverseSuffixSearcher.forwardDFA` replaces `pikevm` field
-- `lazy.CompileWithConfig()` creates forward DFA with config
-- DFA state construction amortized across multiple searches
 
 ---
 
@@ -1519,7 +1536,10 @@ v1.0.0 → Stable release (API frozen)
 
 ---
 
-[Unreleased]: https://github.com/coregx/coregex/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/coregx/coregex/compare/v0.11.3...HEAD
+[0.11.3]: https://github.com/coregx/coregex/releases/tag/v0.11.3
+[0.11.2]: https://github.com/coregx/coregex/releases/tag/v0.11.2
+[0.11.1]: https://github.com/coregx/coregex/releases/tag/v0.11.1
 [0.11.0]: https://github.com/coregx/coregex/releases/tag/v0.11.0
 [0.10.10]: https://github.com/coregx/coregex/releases/tag/v0.10.10
 [0.10.9]: https://github.com/coregx/coregex/releases/tag/v0.10.9

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ coregex automatically selects the optimal engine:
 | Strategy | Pattern Type | Speedup |
 |----------|--------------|---------|
 | **AnchoredLiteral** | `^prefix.*suffix$` | **32-133x** |
-| **MultilineReverseSuffix** | `(?m)^.*\.php` | **3.5-5.7x** |
+| **MultilineReverseSuffix** | `(?m)^/.*\.php` | **319-552x** |
 | ReverseInner | `.*keyword.*` | 100-900x |
 | ReverseSuffix | `.*\.txt` | 100-1100x |
 | BranchDispatch | `^(\d+\|UUID\|hex32)` | 5-20x |

--- a/meta/compile.go
+++ b/meta/compile.go
@@ -235,6 +235,10 @@ func buildReverseSearchers(
 			// Fallback to regular ReverseSuffix or DFA
 			result.finalStrategy = UseDFA
 		} else {
+			// Issue #99: Extract prefix literals for fast path verification
+			// For patterns like (?m)^/.*\.php, prefix is "/" - enables O(1) verification
+			prefixLiterals := extractor.ExtractPrefixes(re)
+			searcher.SetPrefixLiterals(prefixLiterals)
 			result.multilineReverseSuffixSearcher = searcher
 		}
 	}


### PR DESCRIPTION
## Summary
- Prefix verification fast path for `UseMultilineReverseSuffix`
- Pattern `(?m)^/.*\.php` now **319-552x faster** than stdlib

## Algorithm
1. Suffix prefilter finds `.php` candidates (SIMD memmem)
2. SIMD backward scan to find line start (`bytes.LastIndexByte`)
3. O(1) prefix byte check (`/` at line start)
4. Skip-to-next-line on mismatch (avoids O(n²) worst case)
5. DFA fallback for complex patterns without extractable prefix

## Benchmarks (pattern `(?m)^/.*\.php` on 1KB log)

| Operation | coregex | stdlib | Speedup |
|-----------|---------|--------|---------|
| IsMatch | 182 ns | 100 µs | **552x** |
| Find | 240 ns | 81 µs | **338x** |
| CountAll | 58 µs | 18.7 ms | **319x** |

## Test plan
- [x] All multiline tests pass
- [x] No regressions on other patterns
- [x] Linter passes

Fixes #99