### PR TITLE
fix: FindAll now uses UseMultilineReverseSuffix strategy (#102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.11.4] - 2026-01-16
+
+### Fixed
+- **FindAll/FindAllIndex now use UseMultilineReverseSuffix strategy** (Issue #102)
+  - Previously `FindIndicesAt()` was missing dispatch for `UseMultilineReverseSuffix`
+  - `IsMatch`/`Find` were fast (1µs), but `FindAll` was slow (78ms) - **100x gap vs Rust**
+  - After fix: `FindAll` on 6MB with 2000 matches: **~1ms** (was 78ms)
+
+### Changed
+- Updated `golang.org/x/sys` dependency v0.39.0 → v0.40.0
+
+---
+
 ## [0.11.3] - 2026-01-16
 
 ### Changed
@@ -1537,6 +1550,7 @@ v1.0.0 → Stable release (API frozen)
 ---
 
 [Unreleased]: https://github.com/coregx/coregex/compare/v0.11.3...HEAD
+[0.11.4]: https://github.com/coregx/coregex/releases/tag/v0.11.4
 [0.11.3]: https://github.com/coregx/coregex/releases/tag/v0.11.3
 [0.11.2]: https://github.com/coregx/coregex/releases/tag/v0.11.2
 [0.11.1]: https://github.com/coregx/coregex/releases/tag/v0.11.1

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.25.4
 
 require (
 	github.com/coregx/ahocorasick v0.1.0
-	golang.org/x/sys v0.39.0
+	golang.org/x/sys v0.40.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 github.com/coregx/ahocorasick v0.1.0 h1:CiCQwQ/Gu6pahlO3u4jrPo8q0Tb8pLknU7tzqiLRZcw=
 github.com/coregx/ahocorasick v0.1.0/go.mod h1:SDcS9KTiwLP8FHNpYSO3Q3mRqrK8SYJAYpygrhcIils=
-golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
-golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=
+golang.org/x/sys v0.40.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=


### PR DESCRIPTION
## Summary
- `FindIndicesAt()` was missing dispatch case for `UseMultilineReverseSuffix`
- This caused `FindAll`/`FindAllIndex` to fall back to slow NFA path
- `IsMatch`/`Find` were fast (1µs), but `FindAll` was slow (78ms) - **100x gap vs Rust**

## Performance
| Operation | Before | After | Improvement |
|-----------|--------|-------|-------------|
| FindAll (6MB, 2000 matches) | 78ms | ~1ms | **78x faster** |
| vs Rust gap | 100x slower | ~1.3x slower | Near parity |

## Changes
- Add `UseMultilineReverseSuffix` case to `FindIndices()` and `FindIndicesAt()`
- Add helper methods `findIndicesMultilineReverseSuffix()` and `findIndicesMultilineReverseSuffixAt()`
- Update `golang.org/x/sys` v0.39.0 → v0.40.0

## Test plan
- [x] All tests pass (`go test ./...`)
- [x] Lint passes (`golangci-lint run`)
- [ ] CI passes
- [ ] regex-bench verification after merge

Fixes #102