### PR TITLE
fix: UseAnchoredLiteral regression in FindIndices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.11.8] - 2026-02-01
+
+### Fixed
+- **Critical regression in UseAnchoredLiteral strategy** (Issue #107)
+  - `FindIndices*` and `findIndicesAtWithState` were missing `UseAnchoredLiteral` case
+  - Pattern `^/.*[\w-]+\.php$` fell through to slow NFA path: 0.01ms → 408ms (40,000x slower)
+  - Added `findIndicesAnchoredLiteral` and `findIndicesAnchoredLiteralAt` methods
+  - Now correctly uses O(1) anchored literal matching: **408ms → 0.5ms**
+
+---
+
 ## [0.11.7] - 2026-02-01
 
 ### Fixed


### PR DESCRIPTION
## Summary
- Add missing `UseAnchoredLiteral` case to `FindIndices`, `FindIndicesAt`, and `findIndicesAtWithState`
- Add `findIndicesAnchoredLiteral` and `findIndicesAnchoredLiteralAt` methods

## Problem
Pattern `^/.*[\w-]+\.php$` fell through to slow NFA path because `UseAnchoredLiteral` was missing in switch statements.

**Regression**: 0.01ms → 408ms (40,000x slower)

## Fix
**After fix**: 408ms → 0.5ms (O(1) anchored literal matching restored)

## Test plan
- [x] All tests pass
- [x] Linter passes
- [x] Local benchmark confirms fix: `anchored_php: 566µs`

Fixes #107