### PR TITLE
fix: add anchoredFirstBytes check to state-reusing BoundedBacktracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.11.9] - 2026-02-02
+
+### Fixed
+- **Missing first-byte prefilter in FindAll state-reusing path** (Issue #107)
+  - `findIndicesBoundedBacktrackerAtWithState` was missing `anchoredFirstBytes` check
+  - Pattern `^/.*[\w-]+\.php` (without `$`) took 377ms instead of 40µs on 6MB input
+  - Added O(1) early rejection for anchored patterns not starting with required byte
+  - Fix: **377ms → 40µs** (9000x improvement for non-matching anchored patterns)
+
+---
+
 ## [0.11.8] - 2026-02-01
 
 ### Fixed

--- a/meta/find_indices.go
+++ b/meta/find_indices.go
@@ -915,6 +915,15 @@ func (e *Engine) findIndicesBoundedBacktrackerAtWithState(haystack []byte, at in
 	if e.boundedBacktracker == nil {
 		return e.findIndicesNFAAtWithState(haystack, at, state)
 	}
+
+	// O(1) early rejection for anchored patterns using first-byte prefilter.
+	// For pattern ^/.*\.php, reject inputs not starting with "/" immediately.
+	if at == 0 && e.anchoredFirstBytes != nil && len(haystack) > 0 {
+		if !e.anchoredFirstBytes.Contains(haystack[0]) {
+			return -1, -1, false
+		}
+	}
+
 	atomic.AddUint64(&e.stats.NFASearches, 1)
 
 	// Slice to remaining portion for more efficient BoundedBacktracker usage.


### PR DESCRIPTION
## Summary
- Add missing `anchoredFirstBytes` O(1) early rejection check to `findIndicesBoundedBacktrackerAtWithState`

## Problem
Pattern `^/.*[\w-]+\.php` (without `$`) took **377ms** on 6MB input because:
1. `UseBoundedBacktracker` strategy was selected
2. State-reusing `findIndicesBoundedBacktrackerAtWithState` lacked the `anchoredFirstBytes` check
3. Fell back to PikeVM which scanned entire 6MB due to greedy `.*`

## Fix
Added the same O(1) first-byte check that exists in `findIndicesBoundedBacktracker`:
```go
if at == 0 && e.anchoredFirstBytes != nil && len(haystack) > 0 {
    if !e.anchoredFirstBytes.Contains(haystack[0]) {
        return -1, -1, false
    }
}
```

**Result**: 377ms → 40µs (9000x improvement)

## Test plan
- [x] All tests pass
- [x] Linter passes
- [x] Local benchmark: `^/.*[\w-]+\.php` on 6MB: 40µs, 0 matches

Fixes #107