### PR TITLE
fix: reject alternation patterns from ReverseSuffixSet (Issue #116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ARM NEON SIMD support (waiting for Go 1.26 native SIMD)
 - SIMD prefilter for CompositeSequenceDFA (#83)
 
+## [0.12.2] - 2026-02-16
+
+### Fixed
+- **Alternation patterns misrouted to ReverseSuffixSet** (Issue #116) —
+  Patterns like `[cgt]gggtaaa|tttaccc[acg]` (alternation without `.*` prefix)
+  were incorrectly routed to UseReverseSuffixSet strategy, which assumed
+  match always starts at position 0. This produced wrong match boundaries
+  (e.g., `[0, 37976]` instead of `[3, 11]`). Fix: added `isSafeForReverseSuffix`
+  guard before UseReverseSuffixSet selection.
+- **`matchStartZero` optimization too aggressive** — The reverse DFA skip
+  optimization (`matchStartZero`) was enabled for all unanchored patterns,
+  but is only correct for `.*` prefix patterns. Patterns like `[^\s]+\.txt`
+  or `.+\.txt` could return wrong match start positions. Fix: restricted
+  `matchStartZero` to patterns with explicit `OpStar(AnyChar)` prefix.
+
 ## [0.12.1] - 2026-02-15
 
 ### Performance

--- a/meta/compile.go
+++ b/meta/compile.go
@@ -217,7 +217,7 @@ func buildReverseSearchers(
 
 	case UseReverseSuffix:
 		suffixLiterals := extractor.ExtractSuffixes(re)
-		searcher, err := NewReverseSuffixSearcher(nfaEngine, suffixLiterals, dfaConfig)
+		searcher, err := NewReverseSuffixSearcher(nfaEngine, suffixLiterals, dfaConfig, hasDotStarPrefix(re))
 		if err != nil {
 			result.finalStrategy = UseDFA
 		} else {
@@ -226,7 +226,7 @@ func buildReverseSearchers(
 
 	case UseReverseSuffixSet:
 		suffixLiterals := extractor.ExtractSuffixes(re)
-		searcher, err := NewReverseSuffixSetSearcher(nfaEngine, suffixLiterals, dfaConfig)
+		searcher, err := NewReverseSuffixSetSearcher(nfaEngine, suffixLiterals, dfaConfig, hasDotStarPrefix(re))
 		if err != nil {
 			result.finalStrategy = UseBoth
 		} else {

--- a/meta/reverse_suffix_set.go
+++ b/meta/reverse_suffix_set.go
@@ -61,6 +61,7 @@ func NewReverseSuffixSetSearcher(
 	forwardNFA *nfa.NFA,
 	suffixLiterals *literal.Seq,
 	config lazy.Config,
+	matchStartZero bool,
 ) (*ReverseSuffixSetSearcher, error) {
 	if suffixLiterals == nil || suffixLiterals.IsEmpty() {
 		return nil, ErrNoSuffixSet
@@ -103,9 +104,8 @@ func NewReverseSuffixSetSearcher(
 	// Create PikeVM for fallback
 	pikevm := nfa.NewPikeVM(forwardNFA)
 
-	// Check if pattern is unanchored (starts matching from position 0)
-	matchStartZero := !forwardNFA.IsAlwaysAnchored()
-
+	// matchStartZero is true only when pattern has .* prefix (e.g., `.*\.(txt|log|md)`).
+	// Only OpStar(AnyChar) guarantees match starts at 0/at — skip reverse DFA.
 	return &ReverseSuffixSetSearcher{
 		forwardNFA:     forwardNFA,
 		reverseNFA:     reverseNFA,


### PR DESCRIPTION
## Summary

- **Fix alternation patterns misrouted to ReverseSuffixSet** (Issue #116) — patterns like `[cgt]gggtaaa|tttaccc[acg]` (no `.*` prefix) were incorrectly handled, producing wrong match boundaries
- **Fix `matchStartZero` optimization** — restricted to `.*` prefix only via `hasDotStarPrefix()`, was previously enabled for all unanchored patterns

## Root Cause

`shouldUseReverseSuffixSet()` lacked an `isSafeForReverseSuffix(re)` guard, allowing alternation patterns without wildcard prefix to use the ReverseSuffixSet strategy. The `matchStartZero` flag (set via `!forwardNFA.IsAlwaysAnchored()`) then skipped the reverse DFA scan and assumed match starts at 0.

## Test plan

- [x] `TestIssue116_AlternationWithoutWildcard` — 5 cases covering original bug report pattern
- [x] Full test suite passes (`go test ./...`)
- [x] ReverseSuffix/ReverseSuffixSet benchmarks — no regression
- [x] Latent bug verified: `[^\s]+\.txt`, `.+\.txt`, `[a-z]+\.go` all match stdlib
- [ ] CI: tests (3 platforms) + benchmark comparison
- [ ] regex-bench: comparison vs Rust

Fixes #116
