### PR TITLE
docs: update ROADMAP.md to reflect v0.12.6

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > **Strategic Focus**: Production-grade regex engine with RE2/rust-regex level optimizations
 
-**Last Updated**: 2026-03-08 | **Current Version**: v0.12.5 | **Target**: v1.0.0 stable
+**Last Updated**: 2026-03-08 | **Current Version**: v0.12.6 | **Target**: v1.0.0 stable
 
 ---
 
@@ -12,7 +12,7 @@ Build a **production-ready, high-performance regex engine** for Go that matches 
 
 ### Current State vs Target
 
-| Metric | Current (v0.12.5) | Target (v1.0.0) |
+| Metric | Current (v0.12.6) | Target (v1.0.0) |
 |--------|-------------------|-----------------|
 | Inner literal speedup | **280-3154x** | ✅ Achieved |
 | Case-insensitive speedup | **263x** | ✅ Achieved |
@@ -66,7 +66,9 @@ v0.12.3 ✅ → Cross-product literal expansion, 110x speedup on regexdna (#119)
          ↓
 v0.12.4 ✅ → Test coverage 80%+, CI improvements, awesome-go readiness
          ↓
-v0.12.5 (Current) ✅ → Non-greedy quantifier fix, ReverseSuffix correctness (#124)
+v0.12.5 ✅ → Non-greedy quantifier fix, ReverseSuffix correctness (#124)
+         ↓
+v0.12.6 (Current) ✅ → BoundedBacktracker span-based CanHandle, ReplaceAllStringFunc O(n) (#127)
          ↓
 v1.0.0-rc → Feature freeze, API locked
          ↓
@@ -100,6 +102,7 @@ v1.0.0 STABLE → Production release with API stability guarantee
 - ✅ **v0.12.3**: Cross-product literal expansion for regexdna patterns, 110x speedup (#119)
 - ✅ **v0.12.4**: Test coverage 80%+, CI improvements, awesome-go readiness (#123)
 - ✅ **v0.12.5**: Non-greedy quantifier fix, ReverseSuffix forward verification (#124)
+- ✅ **v0.12.6**: BoundedBacktracker span-based CanHandle, ReplaceAllStringFunc O(n) (#127)
 
 ---
 
@@ -191,7 +194,7 @@ v1.0.0 STABLE → Production release with API stability guarantee
 
 ## Feature Comparison Matrix
 
-| Feature | RE2 | rust-regex | coregex v0.12.5 | coregex v1.0 |
+| Feature | RE2 | rust-regex | coregex v0.12.6 | coregex v1.0 |
 |---------|-----|------------|-----------------|--------------|
 | Lazy DFA | ✅ | ✅ | ✅ | ✅ |
 | Thompson NFA | ✅ | ✅ | ✅ | ✅ |
@@ -338,6 +341,9 @@ Reference implementations available locally:
 
 | Version | Date | Type | Key Changes |
 |---------|------|------|-------------|
+| **v0.12.6** | 2026-03-08 | Fix | **BoundedBacktracker span-based CanHandle, ReplaceAllStringFunc O(n) (#127)** |
+| v0.12.5 | 2026-03-08 | Fix | Non-greedy quantifier fix, ReverseSuffix correctness (#124) |
+| v0.12.4 | 2026-03-01 | Test | Test coverage 80%+, CI improvements, awesome-go readiness |
 | **v0.12.3** | 2026-02-16 | Performance | **Cross-product literal expansion, 110x regexdna speedup (#119)** |
 | v0.12.2 | 2026-02-16 | Fix | ReverseSuffixSet safety guard, matchStartZero fix (#116) |
 | v0.12.1 | 2026-02-15 | Performance | DFA bidirectional fallback, digit-run skip, bounded repetitions (#115) |
@@ -375,4 +381,4 @@ Reference implementations available locally:
 
 ---
 
-*Current: v0.12.5 | Next: v0.13.0 | Target: v1.0.0*
+*Current: v0.12.6 | Next: v0.13.0 | Target: v1.0.0*


### PR DESCRIPTION
Update ROADMAP.md version references from v0.12.5 to v0.12.6. Add v0.12.6 to release history and completed milestones.