### PR TITLE
fix: FatTeddy AVX2 correctness + prefilter acceleration + cascading trim

### DIFF
--- a/meta/compile.go
+++ b/meta/compile.go
@@ -510,11 +510,10 @@ func CompileRegexp(re *syntax.Regexp, config Config) (*Engine, error) {
 	// Debug: log final strategy selection
 	debugStrategy(re.String(), strategy, nfaEngine.States(), literals, "")
 
-	// Replace FatTeddy prefilter with Aho-Corasick for ALL strategies.
-	// FatTeddy's AVX2 SIMD has known boundary bugs with FindMatch at non-zero
-	// positions that cause false negatives in FindAll iteration. Aho-Corasick
-	// provides correct O(n) multi-pattern matching. (Issue #137)
-	if pf != nil {
+	// Replace FatTeddy with AC for non-Teddy strategies only.
+	// Non-Teddy strategies need AC for DFA verification path.
+	// For UseTeddy, FatTeddy IS the search engine — keep SIMD.
+	if strategy != UseTeddy && pf != nil {
 		pf = buildACPrefilter(pf)
 	}
 

--- a/meta/find_indices.go
+++ b/meta/find_indices.go
@@ -722,16 +722,6 @@ func (e *Engine) findIndicesTeddy(haystack []byte) (int, int, bool) {
 		return e.findIndicesNFA(haystack)
 	}
 
-	// For Fat Teddy with small haystacks, use Aho-Corasick fallback.
-	if e.fatTeddyFallback != nil && len(haystack) < fatTeddySmallHaystackThreshold {
-		atomic.AddUint64(&e.stats.AhoCorasickSearches, 1)
-		match := e.fatTeddyFallback.Find(haystack, 0)
-		if match == nil {
-			return -1, -1, false
-		}
-		return match.Start, match.End, true
-	}
-
 	atomic.AddUint64(&e.stats.PrefilterHits, 1)
 
 	// Use FindMatch which returns both start and end positions
@@ -759,16 +749,6 @@ func (e *Engine) findIndicesTeddy(haystack []byte) (int, int, bool) {
 func (e *Engine) findIndicesTeddyAt(haystack []byte, at int) (int, int, bool) {
 	if e.prefilter == nil || at >= len(haystack) {
 		return e.findIndicesNFAAt(haystack, at)
-	}
-
-	// For Fat Teddy with small haystacks, use Aho-Corasick fallback.
-	if e.fatTeddyFallback != nil && len(haystack) < fatTeddySmallHaystackThreshold {
-		atomic.AddUint64(&e.stats.AhoCorasickSearches, 1)
-		match := e.fatTeddyFallback.FindAt(haystack, at)
-		if match == nil {
-			return -1, -1, false
-		}
-		return match.Start, match.End, true
 	}
 
 	atomic.AddUint64(&e.stats.PrefilterHits, 1)

--- a/meta/ismatch.go
+++ b/meta/ismatch.go
@@ -135,25 +135,37 @@ func (e *Engine) isMatchNFA(haystack []byte) bool {
 func (e *Engine) isMatchDFA(haystack []byte) bool {
 	atomic.AddUint64(&e.stats.DFASearches, 1)
 
-	// Prefilter fast rejection: if prefilter says no candidates, no match possible.
-	// This is critical for large NFAs with extracted prefix literals (e.g., case-fold
-	// expanded alternations) where DFA cache thrashing dominates runtime.
+	// Prefilter-accelerated matching: use prefilter to skip non-matching regions,
+	// then verify each candidate with anchored DFA or PikeVM.
+	// This is critical for case-insensitive patterns with large NFAs (Issue #137).
 	if e.prefilter != nil {
-		pos := e.prefilter.Find(haystack, 0)
-		if pos == -1 {
-			return false
+		pos := 0
+		for pos < len(haystack) {
+			candidate := e.prefilter.Find(haystack, pos)
+			if candidate == -1 {
+				return false // No more candidates
+			}
+			atomic.AddUint64(&e.stats.PrefilterHits, 1)
+			// For complete prefilters, the find is sufficient
+			if e.prefilter.IsComplete() {
+				return true
+			}
+			// Verify candidate with anchored DFA (O(pattern_len) per candidate).
+			// Unanchored verification would scan to end of input = O(n) per candidate.
+			if e.dfa != nil {
+				if e.dfa.SearchAtAnchored(haystack, candidate) != -1 {
+					return true
+				}
+			} else {
+				// PikeVM fallback — check if match starts at candidate position
+				start, _, found := e.pikevm.SearchAt(haystack, candidate)
+				if found && start == candidate {
+					return true
+				}
+			}
+			pos = candidate + 1
 		}
-		atomic.AddUint64(&e.stats.PrefilterHits, 1)
-		// For complete prefilters, the find is sufficient
-		if e.prefilter.IsComplete() {
-			return true
-		}
-		// Verify candidate with NFA (PikeVM) at the candidate position.
-		// We use NFA instead of DFA for verification because large NFAs
-		// (e.g., 181 states for (?i) patterns) cause DFA cache thrashing.
-		// PikeVM is O(n*states) but avoids DFA construction overhead.
-		_, _, found := e.pikevm.SearchAt(haystack, pos)
-		return found
+		return false
 	}
 
 	// Use DFA.IsMatch which has early termination optimization

--- a/prefilter/teddy_avx2_amd64.s
+++ b/prefilter/teddy_avx2_amd64.s
@@ -149,8 +149,11 @@ loop16:
 	JMP     loop16
 
 handle_tail:
-	// Process remaining bytes one at a time using scalar code
-	// Reset prev0 logic doesn't matter for scalar
+	// Cover the prev0 carry-over position (k*16) that the SIMD loop missed.
+	// The 2-byte fingerprint algorithm uses VPALIGNR to carry prev0 between
+	// SIMD iterations. When exiting to tail, position k*16 hasn't been checked
+	// because the SIMD iteration that would use prev0 never ran.
+	DECQ    SI
 
 tail_check:
 	// Need at least 2 bytes


### PR DESCRIPTION
## Summary

6 changes for FatTeddy correctness, prefilter acceleration, and literal optimization:

1. **FatTeddy AVX2 ANDL→ORL** — lane combining bug: `ANDL` required match in BOTH 128-bit lanes, missing patterns in single lane (GET, PUT). Fix: `ORL`. Also DECQ SI for tail boundary.
2. **Remove AC replacement** — FatTeddy now correct, AC workaround removed. methods `(?i)get|post|put`: 41ms → 11ms.
3. **Prefilter-accelerated isMatchDFA** — candidate loop with anchored DFA verification instead of unanchored PikeVM scan. Issue #137 match case: 176μs → 27μs.
4. **Prefilter-accelerated findIndicesDFA** — same loop for FindIndices (guard: nfaStates > 100 to avoid overhead on small NFAs).
5. **Cascading prefix trim** (Rust-style) — >64 literals trimmed via attempts [(4,64), (3,64), (2,64)]. auth_attempts 128→18 literals → Teddy. 34ms → 10ms.
6. **Regression tests** — FatTeddy lane combining, case-fold FindAll correctness.

## Test plan

- [x] Full test suite passes (`go test ./...`)
- [x] Lint clean (`golangci-lint run`)
- [x] All 13 LangArena match counts verified vs stdlib
- [x] FatTeddy methods: 34368 matches (was 11456 with ANDL bug)
- [x] Bisect: no regressions (peak_hours/errors variance = Go binary layout)
- [ ] CI passes
- [ ] regex-bench validation
