### PR TITLE
docs: update README benchmarks to v0.12.21 EPYC CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,19 +64,20 @@ Cross-language benchmarks on 6MB input, AMD EPYC ([source](https://github.com/ko
 
 | Pattern | Go stdlib | coregex | Rust regex | vs stdlib | vs Rust |
 |---------|-----------|---------|------------|-----------|---------|
-| Literal alternation | 466 ms | 4.2 ms | 0.65 ms | **110x** | 6.4x slower |
-| Multi-literal | 1391 ms | 12.4 ms | 5.3 ms | **112x** | 2.3x slower |
-| Inner `.*keyword.*` | 227 ms | 0.34 ms | 0.32 ms | **668x** | **~parity** |
-| Suffix `.*\.txt` | 228 ms | 2.9 ms | 1.3 ms | **78x** | 2.3x slower |
-| Multiline `(?m)^/.*\.php` | 101 ms | 0.35 ms | 0.72 ms | **288x** | **2.0x faster** |
-| Email validation | 258 ms | 0.51 ms | 0.27 ms | **506x** | 1.8x slower |
-| URL extraction | 259 ms | 0.71 ms | 0.35 ms | **364x** | 2.0x slower |
-| IP address | 493 ms | 0.73 ms | 13.5 ms | **675x** | **18.5x faster** |
-| Char class `[\w]+` | 483 ms | 40.9 ms | 56.0 ms | **11x** | **1.3x faster** |
-| Word repeat `(\w{2,8})+` | 628 ms | 167 ms | 54.8 ms | **3x** | 3.0x slower |
+| Literal alternation | 554 ms | 4.5 ms | 0.72 ms | **122x** | 6.2x slower |
+| Multi-literal | 1572 ms | 12.4 ms | 5.5 ms | **126x** | 2.2x slower |
+| Inner `.*keyword.*` | 238 ms | 0.27 ms | 0.33 ms | **881x** | **1.2x faster** |
+| Suffix `.*\.txt` | 239 ms | 1.9 ms | 1.2 ms | **125x** | 1.5x slower |
+| Multiline `(?m)^/.*\.php` | 102 ms | 0.34 ms | 0.75 ms | **299x** | **2.2x faster** |
+| Email validation | 257 ms | 0.46 ms | 0.31 ms | **557x** | 1.4x slower |
+| URL extraction | 256 ms | 0.62 ms | 0.37 ms | **413x** | 1.6x slower |
+| IP address | 494 ms | 0.72 ms | 13.5 ms | **685x** | **18.8x faster** |
+| Version `\d+.\d+.\d+` | 164 ms | 0.62 ms | 0.79 ms | **263x** | **1.2x faster** |
+| Char class `[\w]+` | 478 ms | 42.1 ms | 56.4 ms | **11x** | **1.3x faster** |
+| Word repeat `(\w{2,8})+` | 690 ms | 180 ms | 54.7 ms | **3x** | 3.2x slower |
 
 **Where coregex excels:**
-- Multiline patterns (`(?m)^/.*\.php`) — **2x faster than Rust**, 288x vs stdlib
+- Multiline patterns (`(?m)^/.*\.php`) — **2.2x faster than Rust**, 299x vs stdlib
 - IP/phone patterns (`\d+\.\d+\.\d+\.\d+`) — SIMD digit prefilter skips non-digit regions
 - Suffix patterns (`.*\.log`, `.*\.txt`) — reverse search optimization (1000x+)
 - Inner literals (`.*error.*`, `.*@example\.com`) — bidirectional DFA (900x+)


### PR DESCRIPTION
Update benchmark table with latest EPYC 9V74 CI results. 5 patterns now beat Rust.